### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+recursive-include src *
+include *.txt
+include *.rst
+global-exclude *.pyc
+global-exclude ._*
+global-exclude *.mo


### PR DESCRIPTION
Thanks for merging my changes, releasing and moving to github!

Apparently the 1.3.1 dist is broken:

```
Getting distribution for 'z3c.dependencychecker'.
error: src/z3c/dependencychecker/USAGE.rst: No such file or directory
An error occured when trying to install z3c.dependencychecker 1.3.1. Look above this message for any errors that were output by easy_install.
While:
  Installing dependencychecker.
  Getting distribution for 'z3c.dependencychecker'.
Error: Couldn't install: z3c.dependencychecker 1.3.1
```

I've added a `MANIFEST.in` which should take care of adding the `USAGE.rst` to the dists.

Cheers,
Jonas
