### PR TITLE
Add support for zipped dists when looking up pkg name.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of z3c.dependencychecker
 1.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add support for zipped dists when looking up pkg name.
 
 
 1.4 (2012-07-03)


### PR DESCRIPTION
`pyru` does return another loader when importing from a zip dist.
It needs special handling.

Sorry for bothering you with such frequent changes :-) I think this is it for a moment..
