### PR TITLE
Fix AttributeError when "magic modules" like email.Header are imported.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of z3c.dependencychecker
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix AttributeError when "magic modules" like email.Header are imported.
 
 
 1.5 (2012-07-03)

--- a/src/z3c/dependencychecker/importchecker.py
+++ b/src/z3c/dependencychecker/importchecker.py
@@ -444,7 +444,7 @@ class ImportDatabase:
             parent_dottedname = '.'.join(dottedname.split('.')[:-1])
             try:
                 loader = runpy.get_loader(parent_dottedname)
-            except ImportError:
+            except (ImportError, AttributeError):
                 loader = None
 
         if not loader:


### PR DESCRIPTION
The import statement "from email.Header import Header" results in an AttributeError.
The email module seems to have some magic import mechanism and breaks usage of pkgutil's get_loader.

With this pull request it just ignores such imports:

``` python
/Users/jone/projects/python/cache/eggs/Products.PloneTestCase-0.9.14-py2.6.egg/Products/PloneTestCase/setup.py:98: DeprecationWarning: zope.testing.testrunner is deprecated in favour of zope.testrunner.
  import zope.testing.testrunner
WARNING: Conflicting security declarations for "setText"
WARNING: Class "ATTopic" had conflicting security declarations
Traceback (most recent call last):
  File "bin/dependencychecker", line 239, in <module>
    z3c.dependencychecker.dependencychecker.main()
  File "/Users/jone/projects/packages/ftw.shop/src/z3c.dependencychecker/src/z3c/dependencychecker/dependencychecker.py", line 342, in main
    install_imports = db.getImportedPkgNames(tests=False)
  File "/Users/jone/projects/packages/ftw.shop/src/z3c.dependencychecker/src/z3c/dependencychecker/importchecker.py", line 324, in getImportedPkgNames
    name = self.resolvePkgName(modulename)
  File "/Users/jone/projects/packages/ftw.shop/src/z3c.dependencychecker/src/z3c/dependencychecker/importchecker.py", line 357, in resolvePkgName
    loader = self._getLoader(dottedname)
  File "/Users/jone/projects/packages/ftw.shop/src/z3c.dependencychecker/src/z3c/dependencychecker/importchecker.py", line 446, in _getLoader
    loader = runpy.get_loader(parent_dottedname)
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.6/pkgutil.py", line 456, in get_loader
    return find_loader(fullname)
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.6/pkgutil.py", line 466, in find_loader
    for importer in iter_importers(fullname):
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.6/pkgutil.py", line 416, in iter_importers
    if fullname.startswith('.'):
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.6/email/__init__.py", line 82, in __getattr__
    return getattr(mod, name)
AttributeError: 'module' object has no attribute 'startswith'
```
