### PR TITLE
Lookup package name for ZCML modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of z3c.dependencychecker
 1.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Lookup package name for ZCML modules too, as it is done for python modules.
 
 
 1.6 (2012-11-01)

--- a/src/z3c/dependencychecker/dependencychecker.py
+++ b/src/z3c/dependencychecker/dependencychecker.py
@@ -344,7 +344,11 @@ def main():
                  sorted(install_imports))
     (install_required, test_required) = existing_requirements()
     stdlib = stdlib_modules()
+
     (zcml_imports, zcml_test_imports) = includes_from_zcml(path)
+    zcml_imports = db.resolvePkgNames(zcml_imports)
+    zcml_test_imports = db.resolvePkgNames(zcml_test_imports)
+
     doctest_imports = imports_from_doctests(path)
 
     print_unused_imports(unused_imports)

--- a/src/z3c/dependencychecker/importchecker.py
+++ b/src/z3c/dependencychecker/importchecker.py
@@ -362,6 +362,20 @@ class ImportDatabase:
         else:
             return None
 
+    def resolvePkgNames(self, modulenames):
+        pkgnames = set()
+
+        for modulename in modulenames:
+            name = self.resolvePkgName(modulename)
+            if name:
+                pkgnames.add(name)
+                logger.debug("Using package '%s' instead of module '%s'",
+                             name, modulename)
+            else:
+                pkgnames.add(modulename)
+
+        return sorted(pkgnames)
+
     def _getPkgNameInSourceDist(self, loader):
         path = loader.get_filename()
         logger.debug("Finding pkg name for %s", path)

--- a/src/z3c/dependencychecker/tests/sample1/src/sample1/configure.zcml_in
+++ b/src/z3c/dependencychecker/tests/sample1/src/sample1/configure.zcml_in
@@ -4,5 +4,6 @@
   <securityPolicy
       component="also.needed.by.zcml.ZopeSecurityPolicy"
       />
+  <include package="zope.interface.verify"/>
 
 </zcml>


### PR DESCRIPTION
This fixes issue #6 (see details there).

In short:
When I have `<include package="Products.Five" />` in ZCML, I want to see a missing dependency `Zope2`, not `Products.Five`, since `Five` is packaged in the `Zope2` egg.
