### PR TITLE
Introducing generic setup support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of z3c.dependencychecker
 1.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Detect generic setup dependencies in ``metadata.xml`` files.
 
 
 1.6 (2012-11-01)

--- a/src/z3c/dependencychecker/USAGE.rst
+++ b/src/z3c/dependencychecker/USAGE.rst
@@ -45,6 +45,7 @@ script would:
     Missing requirements
     ====================
          missing.req
+         other.generic.setup.dependency
          something.origname
          zope.interface
     <BLANKLINE>

--- a/src/z3c/dependencychecker/tests/dependencychecker.txt
+++ b/src/z3c/dependencychecker/tests/dependencychecker.txt
@@ -160,6 +160,16 @@ Finding from-imports in doctests:
     >>> re.findall(dependencychecker.DOCTEST_FROM_IMPORT, input)
     []
 
+Find dependencies in GenericSetup metadata.xml files:
+
+    >>> import re
+    >>> input = ''
+    >>> re.findall(dependencychecker.METADATA_DEPENDENCY_PATTERN, input)
+    []
+    >>> input = '<dependency>profile-package.name:default</dependency>'
+    >>> re.findall(dependencychecker.METADATA_DEPENDENCY_PATTERN, input)
+    ['package.name']
+
 
 Grabbing the name from setup.py
 -------------------------------

--- a/src/z3c/dependencychecker/tests/sample1/setup.py_in
+++ b/src/z3c/dependencychecker/tests/sample1/setup.py_in
@@ -25,6 +25,7 @@ setup(name='sample1',
           # ^^^ Note: capitalized to test case-insensitive pypi
           'needed.by.zcml',
           'also.needed.by.zcml',
+          'generic.setup.dependency',
           ],
       extras_require = {
           'test': [

--- a/src/z3c/dependencychecker/tests/sample1/src/sample1.egg-info_in/requires.txt
+++ b/src/z3c/dependencychecker/tests/sample1/src/sample1.egg-info_in/requires.txt
@@ -4,6 +4,7 @@ unneeded.req
 Needed.By.Test
 needed.by.zcml
 also.needed.by.zcml
+generic.setup.dependency
 
 [test]
 my.package


### PR DESCRIPTION
This PR also adds support for checking Generic Setup dependencies, defined in `metadata.xml`.
Details are in issue #7.

@reinout I'm not sure if this should be in z3c.dependencychecker, since Generic Setup is a Plone thing, not Zope. But since the feature does not introduce dependencies or impact the checking of packages without a `metadata.xml`, I think it is arguable.

The change would help a lot in policy packages, where this situation is quite usual.
