### PR TITLE
support extras_require

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of z3c.dependencychecker
 1.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Treat non-test extras_require like normal install_requires.
 
 
 1.9 (2013-02-13)

--- a/src/z3c/dependencychecker/USAGE.rst
+++ b/src/z3c/dependencychecker/USAGE.rst
@@ -57,6 +57,7 @@ script would:
     <BLANKLINE>
     Unneeded requirements
     =====================
+         some.other.extension
          unneeded.req
     <BLANKLINE>
     Requirements that should be test requirements

--- a/src/z3c/dependencychecker/dependencychecker.py
+++ b/src/z3c/dependencychecker/dependencychecker.py
@@ -172,22 +172,19 @@ def existing_requirements():
     lines = [line for line in lines if line]
     install_required = []
     test_required = []
-    for line in lines:
-        if line.startswith('['):
-            break
-        req = pkg_resources.Requirement.parse(line)
-        install_required.append(req.project_name)
-    start = False
+
+    current_section = install_required
     for line in lines:
         if line in ('[test]', '[tests]'):
-            start = True
+            current_section = test_required
             continue
-        if not start:
+
+        elif line.startswith('['):
+            current_section = install_required
             continue
-        if line.startswith('['):
-            break
+
         req = pkg_resources.Requirement.parse(line)
-        test_required.append(req.project_name)
+        current_section.append(req.project_name)
 
     # The project itself is of course both available and needed.
     install_required.append(name)

--- a/src/z3c/dependencychecker/tests/sample1/src/sample1.egg-info_in/requires.txt
+++ b/src/z3c/dependencychecker/tests/sample1/src/sample1.egg-info_in/requires.txt
@@ -14,4 +14,4 @@ zope.testbrowser
 zope.testing
 
 [someotherextension]
-we don't bother with this
+some.other.extension


### PR DESCRIPTION
Hey @reinout ,

I have products which have `extras_require` because they provide integration of other addons but do not require them. If the extras-packages are installed it will load additional ZCML (using `zcml:configure="installed other.package"`).

The dependencychecker lists those packages as missing requirements, which is a little annoying.

How could we handle this properly?

Maybe we could just kind of merge all extras_requires (excluding name "test.*") to the normal requirements for checking, so that they are no longer "missing".

I would spend some time on implementing this, but I'm not sure how it should work.
What do you think?

Cheers
