### PR TITLE
setuptools needs to be installed globally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog of z3c.dependencychecker
 1.11 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Support python installations without global setuptools installed
+  by searching the name in the setup.py as fallback.
 
 
 1.10 (2013-02-24)

--- a/src/z3c/dependencychecker/dependencychecker.py
+++ b/src/z3c/dependencychecker/dependencychecker.py
@@ -110,6 +110,12 @@ profile-     # Profile prefix
 """, re.VERBOSE)
 
 
+SETUP_PY_PACKAGE_NAME_PATTERN = re.compile(r"""
+name\W*=\W*        # 'name =  ' with possible whitespace
+["']([\w.]*)["']   # A string containing the name
+""", re.VERBOSE)
+
+
 def normalize(package_name):
     """Return normalized package name.
 
@@ -137,6 +143,13 @@ def name_from_setup():
     cmd = "%s setup.py --name" % sys.executable
     name = commands.getoutput(cmd).strip()
     if 'traceback' in name.lower():
+
+        # Try to get the package name from setup.py
+        setup = open('setup.py').read()
+        match = SETUP_PY_PACKAGE_NAME_PATTERN.search(setup)
+        if match:
+            return match.groups()[0]
+
         print "You probably don't have setuptools installed globally"
         print "Or there's an error in your setup.py."
         print "Try running this by hand:"


### PR DESCRIPTION
In [name_from_setup()](https://github.com/reinout/z3c.dependencychecker/blob/master/src/z3c/dependencychecker/dependencychecker.py#L137) the name of the package is retrieved by calling `pythonX setup.py --name`, which requires `setuptools` to be installed globally.

Is there a possibility to do this without having `setuptools` installed globally?

Because of the version conflicts and the new buildout versions I've removed everything from site-packages (including distribute, pip, easy_install, setuptools, etc).
It works well in general (I've less buildout problems) but now I can no longer use `z3c.dependencychecker` because of the missing `setuptools`.

Would be very happy to change this to an isolated way, so that I can keep the empty site-packages - but I've no idea how this could be done properly :/

An idea?
