### PR TITLE
Add FTI support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog of z3c.dependencychecker
 - Internal project updates (buildout version, test adjustments, etc).
   [gforcada]
 
+- Add support for FTI dependencies (behaviors, schema and class).
+  [gforcada]
 
 1.11 (2013-04-16)
 -----------------

--- a/src/z3c/dependencychecker/USAGE.rst
+++ b/src/z3c/dependencychecker/USAGE.rst
@@ -47,6 +47,10 @@ script would:
          Products.GenericSetup.interfaces.EXTENSION
          missing.req
          other.generic.setup.dependency
+         plone.app.content.interfaces.INameFromTitle
+         plone.app.dexterity.behaviors.metadata.IBasic
+         plone.random1.interfaces.IMySchema
+         plone.random2.content.MyType
          some_django_app
          something.origname
          zope.interface

--- a/src/z3c/dependencychecker/tests/dependencychecker.txt
+++ b/src/z3c/dependencychecker/tests/dependencychecker.txt
@@ -163,6 +163,33 @@ Finding for="" in zcml files:
     >>> re.findall(dependencychecker.ZCML_FOR_PATTERN, input)
     ['Products.CMFPlone.interfaces.IPloneSiteroot']
 
+Finding behaviors on plone FTI files:
+
+    >>> input = ''
+    >>> re.findall(dependencychecker.FTI_BEHAVIOR_PATTERN, input)
+    []
+    >>> input = '\n<element value="Products.CMFPlone.interfaces.IPloneSiteroot"/>'
+    >>> re.findall(dependencychecker.FTI_BEHAVIOR_PATTERN, input)
+    ['Products.CMFPlone.interfaces.IPloneSiteroot']
+
+Finding schema definitions on plone FTI files:
+
+    >>> input = ''
+    >>> re.findall(dependencychecker.FTI_SCHEMA_PATTERN, input)
+    []
+    >>> input = '\nname="schema">Products.CMFPlone.interfaces.IPloneSiteroot<'
+    >>> re.findall(dependencychecker.FTI_SCHEMA_PATTERN, input)
+    ['Products.CMFPlone.interfaces.IPloneSiteroot']
+
+Finding class definitions on plone FTI files:
+
+    >>> input = ''
+    >>> re.findall(dependencychecker.FTI_KLASS_PATTERN, input)
+    []
+    >>> input = '\nname="klass">Products.CMFPlone.interfaces.IPloneSiteroot<'
+    >>> re.findall(dependencychecker.FTI_KLASS_PATTERN, input)
+    ['Products.CMFPlone.interfaces.IPloneSiteroot']
+
 Finding imports in doctests:
 
     >>> input = ''

--- a/src/z3c/dependencychecker/tests/sample1/src/sample1/profiles/default/types/dummy.xml
+++ b/src/z3c/dependencychecker/tests/sample1/src/sample1/profiles/default/types/dummy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object meta_type="Dexterity FTI">
+  <property name="schema">plone.random1.interfaces.IMySchema</property>
+  <property name="klass">plone.random2.content.MyType</property>
+  <property name="behaviors">
+    <element value="plone.app.content.interfaces.INameFromTitle"/>
+    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+  </property>
+
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+</object>


### PR DESCRIPTION
Plone add-ons may install new content types,
which are defined in XML files where some dependencies maybe hidden.