### PR TITLE
Only alphanumeric characters on imports

### DIFF
--- a/src/z3c/dependencychecker/USAGE.rst
+++ b/src/z3c/dependencychecker/USAGE.rst
@@ -60,6 +60,7 @@ script would:
          plone.dexterity.browser.views.ContentTypeView
          plone.dexterity.interfaces.IContentType
          reinout.hurray
+         transaction
          zope.filerepresentation.interfaces.IRawReadFile"
     <BLANKLINE>
     Unneeded requirements

--- a/src/z3c/dependencychecker/dependencychecker.py
+++ b/src/z3c/dependencychecker/dependencychecker.py
@@ -140,7 +140,7 @@ DOCTEST_IMPORT = re.compile(r"""
 import       # 'import' keyword
 \s+          # Whitespace
 (?P<module>  # Start of 'module' variable.
-\S+          # Non-whitespace string.
+[\w.]+       # Alpha-numeric characters.
 )            # End of 'import' variable.
 """, re.VERBOSE)
 

--- a/src/z3c/dependencychecker/tests/sample1/src/sample1/tests/doctest.txt_in
+++ b/src/z3c/dependencychecker/tests/sample1/src/sample1/tests/doctest.txt_in
@@ -7,6 +7,10 @@ Import from zope.testbrowser:
 
     >>> import zope.testbrowser
 
+Import with semicolon:
+
+    >>> import transaction; transaction.commit()
+
 From-style import:
 
     >>> from my.package import Party


### PR DESCRIPTION
Using \S+ on a regular expression matches 'transaction;' as ';' is a
non-space character.

Changing the 'S' by a 'w' (alphanumeric characters) fixes it.