### PR TITLE
Detect packages with dotted names, too

### DIFF
--- a/src/z3c/dependencychecker/USAGE.rst
+++ b/src/z3c/dependencychecker/USAGE.rst
@@ -38,9 +38,9 @@ script would:
     >>> dependencychecker.main()
     Unused imports
     ==============
-    /TESTTEMP/sample1/src/sample1/unusedimports.py:7:  tempfile
-    /TESTTEMP/sample1/src/sample1/unusedimports.py:4:  zest.releaser
-    /TESTTEMP/sample1/src/sample1/unusedimports.py:6:  os
+    src/sample1/unusedimports.py:7:  tempfile
+    src/sample1/unusedimports.py:4:  zest.releaser
+    src/sample1/unusedimports.py:6:  os
     <BLANKLINE>
     Missing requirements
     ====================

--- a/src/z3c/dependencychecker/dependencychecker.py
+++ b/src/z3c/dependencychecker/dependencychecker.py
@@ -552,7 +552,6 @@ def main():
     logging.basicConfig(level=loglevel, format="%(levelname)s: %(message)s")
 
     path = determine_path(args)
-    # import pdb;pdb.set_trace()
     db = importchecker.ImportDatabase(path)
     db.findModules()
     unused_imports = db.getUnusedImports()

--- a/src/z3c/dependencychecker/dependencychecker.py
+++ b/src/z3c/dependencychecker/dependencychecker.py
@@ -526,6 +526,10 @@ def print_modules(modules, heading):
 def determine_path(args, name=None):
     if len(args) > 0:
         path = args[0]
+        if not os.path.isdir(path):
+            logger.error("You passed %s as a path, but that is no directory!",
+                         path)
+            sys.exit(1)
         logger.debug("Looking in directory %s, passed on the commmand line",
                      path)
         return path
@@ -540,14 +544,14 @@ def determine_path(args, name=None):
         path = os.path.join(*path.split('.'))
         logger.debug("Treating periods as directories: %s", path)
 
-    if os.path.exists(path):
+    if os.path.isdir(path):
         logger.debug("Found base directory at %s", path)
         return path
 
     logger.debug("Directory %s does not exist, trying with src/ prefix",
                  path)
     path = os.path.join('src', path)
-    if os.path.exists(path):
+    if os.path.isdir(path):
         logger.debug("Found base directory at %s", path)
         return path
 

--- a/src/z3c/dependencychecker/dependencychecker.py
+++ b/src/z3c/dependencychecker/dependencychecker.py
@@ -436,8 +436,8 @@ def includes_from_generic_setup_metadata(path):
     test_modules = []
     for path, dirs, files in os.walk(path):
         for xmlfile in [os.path.abspath(os.path.join(path, filename))
-                     for filename in files
-                     if fnmatch.fnmatch(filename, 'metadata.xml')]:
+                        for filename in files
+                        if fnmatch.fnmatch(filename, 'metadata.xml')]:
             contents = open(xmlfile).read()
             found = [module for module in
                      re.findall(METADATA_DEPENDENCY_PATTERN, contents)
@@ -459,7 +459,6 @@ def includes_from_django_settings(path):
         for settingsfile in [os.path.abspath(os.path.join(path, filename))
                              for filename in files
                              if fnmatch.fnmatch(filename, '*settings.py')]:
-            contents = open(settingsfile).read()
             found = []
             parsed = ast.parse(open(settingsfile).read())
             # We're looking for assignments like ``INSTALLED_APPS = ``.

--- a/src/z3c/dependencychecker/importchecker.py
+++ b/src/z3c/dependencychecker/importchecker.py
@@ -354,13 +354,16 @@ class ImportDatabase:
         return result
 
     def resolvePkgName(self, dottedname):
-        loader = self._getLoader(dottedname)
+        try:
+            loader = self._getLoader(dottedname)
+        except AttributeError:
+            # AttributeError: 'NoneType' object has no attribute 'startswith'
+            logger.warn("Module %s is not importable!", dottedname)
+            return
         if isinstance(loader, ImpLoader):
             return self._getPkgNameInSourceDist(loader)
         elif isinstance(loader, zipimporter):
             return self._getPkgNameInZipDist(loader)
-        else:
-            return None
 
     def resolvePkgNames(self, modulenames):
         pkgnames = set()

--- a/src/z3c/dependencychecker/importchecker.py
+++ b/src/z3c/dependencychecker/importchecker.py
@@ -281,7 +281,7 @@ class ImportDatabase:
             path = self.resolveDottedModuleName(from_module_name, module)
             t = (path, name)
             modulepaths = names.get(t, {})
-            if not self_path in modulepaths:
+            if self_path not in modulepaths:
                 modulepaths[self_path] = 1
             names[t] = modulepaths
 

--- a/src/z3c/dependencychecker/tests/dependencychecker.txt
+++ b/src/z3c/dependencychecker/tests/dependencychecker.txt
@@ -90,28 +90,28 @@ Exact matches are fine:
 
     >>> imports = ['zope.interface']
     >>> required = ['zope.interface']
-    >>> dependencychecker.filter_unneeded(imports, required)
+    >>> dependencychecker.filter_unneeded(imports, required, name='test')
     []
 
 Too-specific requirements are reported:
 
     >>> imports = ['zope']
     >>> required = ['zope.interface']
-    >>> dependencychecker.filter_unneeded(imports, required)
+    >>> dependencychecker.filter_unneeded(imports, required, name='test')
     ['zope.interface']
 
 There are no duplicates in the output:
 
     >>> imports = []
     >>> required = ['a', 'a']
-    >>> dependencychecker.filter_unneeded(imports, required)
+    >>> dependencychecker.filter_unneeded(imports, required, name='test')
     ['a']
 
 And the output is sorted:
 
     >>> imports = []
     >>> required = ['a', 'c', 'b']
-    >>> dependencychecker.filter_unneeded(imports, required)
+    >>> dependencychecker.filter_unneeded(imports, required, name='test')
     ['a', 'b', 'c']
 
 
@@ -352,7 +352,7 @@ If we grab the requirements now, we hit two corner cases:
 
 Grab it and watch the fireworks:
 
-    >>> dependencychecker.existing_requirements()
+    >>> dependencychecker.existing_requirements(name='test')
     Traceback (most recent call last):
     ...
     MockExitException: 1
@@ -373,7 +373,7 @@ Pass the path on the command line:
 Pass a non-existing path:
 
     >>> args = ['/does/not/exist']
-    >>> dependencychecker.determine_path(args)
+    >>> dependencychecker.determine_path(args, name='test')
     Traceback (most recent call last):
     ...
     MockExitException: 1
@@ -381,7 +381,7 @@ Pass a non-existing path:
 Pass a file instead of a directory:
 
     >>> args = [setup_py]
-    >>> dependencychecker.determine_path(args)
+    >>> dependencychecker.determine_path(args, name='test')
     Traceback (most recent call last):
     ...
     MockExitException: 1


### PR DESCRIPTION
I've made a bunch of base-directory-detection changes.

I can now also use it out-of-the-box for zest.releaser and mr.developer.

Also added more logging to help debug various issues that cropped up.

@jone or @gforcada, could one of you take a quick look to see if you spot something that's wrong?