### PR TITLE
Better dir iteration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ Changelog of z3c.dependencychecker
   directory. Everything moved one level up.
   [reinout]
 
+- Dependencychecker doesn't descend anymore into directories without an
+  ``__init__.py``. This helps with website projects that sometimes have python
+  files buried deep in directories that aren't actually part of the project's
+  python code.
+  [reinout]
+
 
 1.12 (2015-08-16)
 -----------------

--- a/z3c/dependencychecker/importchecker.py
+++ b/z3c/dependencychecker/importchecker.py
@@ -286,16 +286,16 @@ class ImportDatabase:
         """returns all  names imported by modules"""
         result = set()
         import os
-        for path, module in self._modules.items():
+        for filepath, module in self._modules.items():
             # remove .py
-            parts = path[:-3].split(os.path.sep)
+            parts = filepath[:-3].split(os.path.sep)
             isTest = 'tests' in parts or 'testing' in parts \
                      or 'ftests' in parts
             if (tests and not isTest) or (not tests and isTest):
                 continue
             module_names = module.getImportedModuleNames()
             logger.debug("Modules found in %s (test-only: %s):\n    %s",
-                         path, isTest, sorted(module_names))
+                         filepath, isTest, sorted(module_names))
             result.update(module_names)
         logger.debug("All modules found (test-only: %s):\n    %s",
                      isTest, sorted(result))

--- a/z3c/dependencychecker/importchecker.py
+++ b/z3c/dependencychecker/importchecker.py
@@ -297,8 +297,11 @@ class ImportDatabase:
             logger.debug("Modules found in %s (test-only: %s):\n    %s",
                          filepath, isTest, sorted(module_names))
             result.update(module_names)
-        logger.debug("All modules found (test-only: %s):\n    %s",
-                     isTest, sorted(result))
+        if result:
+            logger.debug("All modules found (test-only: %s):\n    %s",
+                         isTest, sorted(result))
+        else:
+            logger.debug("No imported modules found.")
         return sorted(result)
 
     def getImportedPkgNames(self, tests=False):

--- a/z3c/dependencychecker/importchecker.py
+++ b/z3c/dependencychecker/importchecker.py
@@ -187,31 +187,20 @@ class Module:
         return result
 
 
-class ModuleFinder:
-
-    def __init__(self):
-        self._files = []
-
-    def visit(self, arg, dirname, names):
-        """This method will be called when we walk the filesystem
-        tree. It looks for python modules and stored their filenames.
-        """
-        for name in names:
-            # get all .py files that aren't weirdo emacs droppings
-            if name.endswith('.py') and not name.startswith('.#'):
-                self._files.append(os.path.join(dirname, name))
-
-    def getModuleFilenames(self):
-        return self._files
-
-
 def findModules(path):
-    """Find python modules in the given path and return their absolute
-    filenames in a sequence.
+    """Return absolute filenames of all python modules in the given path.
     """
-    finder = ModuleFinder()
-    os.path.walk(path, finder.visit, ())
-    return finder.getModuleFilenames()
+    result = []
+    for dirpath, dirnames, filenames in os.walk(path):
+        if '__init__.py' not in filenames:
+            # Don't descend further into the tree. Clear dirnames in-place.
+            dirnames[:] = []
+            continue
+        result += [os.path.join(dirpath, filename)
+                   for filename in filenames
+                   if filename.endswith('.py')
+                   and not filename.startswith('.#')]
+    return result
 
 
 class ImportDatabase:

--- a/z3c/dependencychecker/tests/test_setup.py
+++ b/z3c/dependencychecker/tests/test_setup.py
@@ -76,6 +76,9 @@ def setup(test):
             if not filename.endswith('_in'):
                 continue
             new_filename = filename.replace('_in', '')
+            if new_filename == '_it__.py':
+                # Oopsie :-) The replace works too well...
+                new_filename = '__init__.py'
             source = os.path.join(dirpath, filename)
             target = os.path.join(dirpath, new_filename)
             os.rename(source, target)


### PR DESCRIPTION
Dependencychecker doesn't descend anymore into directories without an
`__init__.py`. This helps with website projects that sometimes have python
files buried deep in directories that aren't actually part of the project's
python code.

Use case: I have a website with a buildout that downloads directory full of various javascript projects. One of those projects included a python file, leading to weird reports. Stopping iteration when there's no __init__.py in the directory is a simple fix.

I double-checked the results on four completely different projects and the results are fine.