### PR TITLE
Handle imports with the same root on multiple lines

### DIFF
--- a/z3c/dependencychecker/USAGE.rst
+++ b/z3c/dependencychecker/USAGE.rst
@@ -53,6 +53,7 @@ script would:
          plone.random2.content.MyType
          some_django_app
          something.origname
+         zope.exceptions
          zope.interface
     <BLANKLINE>
     Missing test requirements

--- a/z3c/dependencychecker/tests/sample1/src/sample1/fromimports.py_in
+++ b/z3c/dependencychecker/tests/sample1/src/sample1/fromimports.py_in
@@ -1,8 +1,10 @@
 """Test the from imports"""
 
 from zope import interface
+from zope import exceptions
 from something import origname as newname
 
 # Use it to prevent "unused!" warnings
 interface
 newname
+exceptions


### PR DESCRIPTION
Up until this commit the second import was completely ignored:

```
from zope import interface, something, bananas
from zope import component, whatnot
```

With this commit ``zope.component`` and ``zope.whatnot`` will be included
as dependencies.

Fixes https://github.com/reinout/z3c.dependencychecker/issues/23