### PR TITLE
Add coverage integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,6 @@ branch = True
 [report]
 omit =
     */migrations/*
-    */test*
     /Library/*
     *buildout/eggs/*
     /usr/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+branch = True
+
 [report]
 omit =
     */migrations/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,7 @@ omit =
     eggs/*
     local_checkouts/*
     parts/*
+    bin/*
+    */site-packages/*
 
 ignore_errors = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ install:
   - bin/buildout
 script:
   - bin/test
+after_success:
+  - bin/createcoverage
+  - pip install coveralls
+  - coveralls

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,6 +7,7 @@ parts =
     omelette
     console_scripts
     code-analysis
+    createcoverage
 develop =
     .
 eggs =
@@ -18,6 +19,8 @@ show-picked-versions = true
 z3c.dependencychecker =
 collective.recipe.omelette = 0.16
 colorama = 0.3.3
+coverage = 4.4.1
+createcoverage = 1.5
 martian = 0.15
 pep8 = 1.6.2
 setuptools = 18.1
@@ -50,6 +53,9 @@ eggs =
     z3c.dependencychecker
     z3c.dependencychecker[test]
 
+[createcoverage]
+recipe = zc.recipe.egg
+eggs = createcoverage
 
 [console_scripts]
 recipe = zc.recipe.egg


### PR DESCRIPTION
@reinout if you agree on these changes, first of all https://coveralls.io should be enabled, to do so one needs to log in on coveralls.io and click around.

My idea is to try to tackle the rewrite of importchecker.py at some point to use the ast module so it can be more reliable. Actually, now that I realize, this is also a blocker for z3c.dependencychecker itself to be usable in Python 3 (see #32)

The main idea behind this is that plone, on the way to become a python 3 citizen it should also clean up its completely tangled dependency graph. If we don't get all the dependencies on setup.py first, that's nearly to impossible, so we need z3c.dependencychecker to help us on that!