### PR TITLE
Database and Package

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ py==1.4.34
 pycparser==2.18
 pyOpenSSL==17.2.0
 pytest==3.2.1
+pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 requests==2.18.4
 six==1.10.0

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+
+class ImportsDatabase(object):
+    """Store all imports and requirements of a package
+
+    Use that information to extract useful data out of it,
+    like requirements unused, etc.
+    """
+
+    def __init__(self):
+        self._requirements = set()
+
+    def add_requirements(self, requirements):
+        self._requirements = set([
+            requirement for requirement in requirements
+        ])

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class ImportsDatabase(object):
@@ -10,8 +14,32 @@ class ImportsDatabase(object):
 
     def __init__(self):
         self._requirements = set()
+        self._extras_requirements = {}
 
     def add_requirements(self, requirements):
         self._requirements = set([
             requirement for requirement in requirements
         ])
+
+    def add_extra_requirements(self, extra_name, dotted_names):
+        # A bit of extra work needs to be done as pkg_resources API returns
+        # all common requirements as well as the extras when asking for an
+        # extra requirements.
+        only_extra_dotted_names = self._filter_duplicates(dotted_names)
+        if extra_name in self._extras_requirements.keys():
+            self._extras_requirements[extra_name].update(
+                only_extra_dotted_names,
+            )
+
+            logger.warn(
+                'extra requirement "%s" is declared twice on setup.py',
+                extra_name,
+            )
+        else:
+            self._extras_requirements[extra_name] = only_extra_dotted_names
+
+    def _filter_duplicates(self, imports):
+        """Return all items in imports that are not found in reference"""
+        all_imports = set([dotted_name for dotted_name in imports])
+        filtered = all_imports - self._requirements
+        return filtered

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -196,3 +196,10 @@ class Package(object):
         self.imports.add_requirements(
             self.metadata.get_required_dependencies()
         )
+
+    def set_declared_extras_dependencies(self):
+        """Add this packages' extras dependencies defined in setup.py to the
+        database
+        """
+        for extra, dotted_names in self.metadata.get_extras_dependencies():
+            self.imports.add_extra_requirements(extra, dotted_names)

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -176,3 +176,14 @@ class PackageMetadata(object):
             os.sep,
         )
         sys.exit(1)
+
+
+class Package(object):
+    """The python package that is being analyzed
+
+    This class itself does not much per se, but connects the PackageMetadata
+    with the ImportsDatabase, where the important bits are.
+    """
+
+    def __init__(self, path):
+        self.metadata = PackageMetadata(path)

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from z3c.dependencychecker.db import ImportsDatabase
 from z3c.dependencychecker.dotted_name import DottedName
 from z3c.dependencychecker.utils import change_dir
 import glob
@@ -187,3 +188,11 @@ class Package(object):
 
     def __init__(self, path):
         self.metadata = PackageMetadata(path)
+        self.imports = ImportsDatabase()
+
+    def set_declared_dependencies(self):
+        """Add this packages' dependencies defined in setup.py to the database
+        """
+        self.imports.add_requirements(
+            self.metadata.get_required_dependencies()
+        )

--- a/z3c/dependencychecker/tests/test_imports_database.py
+++ b/z3c/dependencychecker/tests/test_imports_database.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from z3c.dependencychecker.dotted_name import DottedName
 from z3c.dependencychecker.db import ImportsDatabase
+from z3c.dependencychecker.tests.utils import get_extras_requirements_names
 from z3c.dependencychecker.tests.utils import get_requirements_names
+from z3c.dependencychecker.tests.utils import get_requirements_names_for_extra
 
 
 def test_no_dependencies():
@@ -37,3 +39,78 @@ def test_declared_dependencies_no_duplicates():
 
     requirements = get_requirements_names(database)
     assert len(requirements) == 3
+
+
+def test_no_extras():
+    database = ImportsDatabase()
+    assert len(get_extras_requirements_names(database)) == 0
+
+
+def test_extras_requirements_key_names():
+    database = ImportsDatabase()
+    database.add_extra_requirements('test', [DottedName('one'), ])
+    database.add_extra_requirements('plone', [DottedName('two'), ])
+
+    extras = get_extras_requirements_names(database)
+    assert len(extras) == 2
+    assert 'test' in extras
+    assert 'plone' in extras
+
+
+def test_add_extra_dependencies():
+    database = ImportsDatabase()
+    imports = [
+        DottedName('one'),
+        DottedName('two'),
+    ]
+    database.add_extra_requirements('test', imports)
+
+    test_extras = get_requirements_names_for_extra(database, extra='test')
+    assert len(test_extras) == 2
+    assert 'one' in test_extras
+    assert 'two' in test_extras
+
+
+def test_warning_extra_declared_twice(caplog):
+    """Show a warning if an extra is declared twice on setup.py"""
+    database = ImportsDatabase()
+    database.add_extra_requirements('test', [DottedName('one', )])
+    database.add_extra_requirements('test', [DottedName('two', )])
+
+    last_log = caplog.records[-1]
+    message = 'extra requirement "test" is declared twice on setup.py'
+    assert message == last_log.message
+
+
+def test_direct_requirements_filtered_on_extras():
+    """Check that direct requirements are filtered when added to an extra"""
+    database = ImportsDatabase()
+    database.add_requirements([DottedName('one'), DottedName('two', )])
+    database.add_extra_requirements(
+        'test',
+        [DottedName('one', ), DottedName('three', ), ],
+    )
+
+    test_extras = get_requirements_names_for_extra(database, extra='test')
+    assert len(test_extras) == 1
+    assert 'three' in test_extras
+    assert 'one' not in test_extras
+
+
+def test_filter_duplicate_extra_requirements():
+    """If an extra is declared twice, duplicate requirements are filtered"""
+    database = ImportsDatabase()
+    database.add_extra_requirements(
+        'test',
+        [DottedName('one', ), DottedName('three', ), ],
+    )
+    database.add_extra_requirements(
+        'test',
+        [DottedName('two', ), DottedName('three', ), ],
+    )
+
+    test_extras = get_requirements_names_for_extra(database, extra='test')
+    assert len(test_extras) == 3
+    assert 'one' in test_extras
+    assert 'two' in test_extras
+    assert 'three' in test_extras

--- a/z3c/dependencychecker/tests/test_imports_database.py
+++ b/z3c/dependencychecker/tests/test_imports_database.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from z3c.dependencychecker.dotted_name import DottedName
+from z3c.dependencychecker.db import ImportsDatabase
+from z3c.dependencychecker.tests.utils import get_requirements_names
+
+
+def test_no_dependencies():
+    database = ImportsDatabase()
+    assert isinstance(database._requirements, set)
+    assert len(database._requirements) == 0
+
+
+def test_add_dependencies():
+    database = ImportsDatabase()
+    database.add_requirements([
+        DottedName('one'),
+        DottedName('two'),
+    ])
+
+    names = get_requirements_names(database)
+    assert len(names) == 2
+    assert 'one' in names
+    assert 'two' in names
+
+
+def test_declared_dependencies_no_duplicates():
+    """Check that if there are duplicated requirements,
+    they are correctly filtered and only one remains
+    """
+    database = ImportsDatabase()
+    database.add_requirements([
+        DottedName('one'),
+        DottedName('two'),
+        DottedName('three'),
+        DottedName('one'),
+    ])
+
+    requirements = get_requirements_names(database)
+    assert len(requirements) == 3

--- a/z3c/dependencychecker/tests/test_package.py
+++ b/z3c/dependencychecker/tests/test_package.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from z3c.dependencychecker.package import Package
 from z3c.dependencychecker.package import PackageMetadata
+from z3c.dependencychecker.tests.utils import get_extras_requirements_names
 from z3c.dependencychecker.tests.utils import get_requirements_names
+from z3c.dependencychecker.tests.utils import get_requirements_names_for_extra
 import os
 
 
@@ -38,3 +40,81 @@ def test_declared_dependencies_empty(minimal_structure):
     package.set_declared_dependencies()
 
     assert len(get_requirements_names(package.imports)) == 0
+
+
+def test_declared_extras_dependencies_one_extra(minimal_structure):
+    path, package_name = minimal_structure
+    requires_file_path = os.path.join(
+        path,
+        '{0}.egg-info'.format(package_name),
+        'requires.txt',
+    )
+    with open(requires_file_path, 'w') as requires:
+        requires.write('\n'.join([
+            '[extra]',
+            'my.package',
+            'another.package',
+        ]))
+
+    package = Package(path)
+    package.set_declared_dependencies()
+    package.set_declared_extras_dependencies()
+
+    assert get_extras_requirements_names(package.imports) == ['extra', ]
+    names = get_requirements_names_for_extra(package.imports, extra='extra')
+    assert 'another.package' in names
+    assert 'my.package' in names
+
+
+def test_declared_extras_dependencies_only_on_extras(minimal_structure):
+    """Check that main dependencies are not bundled on the extras"""
+    path, package_name = minimal_structure
+    requires_file_path = os.path.join(
+        path,
+        '{0}.egg-info'.format(package_name),
+        'requires.txt',
+    )
+    with open(requires_file_path, 'w') as requires:
+        requires.write('\n'.join([
+            'setuptools',
+            '',
+            '[extra]',
+            'my_package',
+            'my_other_package',
+        ]))
+
+    package = Package(path)
+    package.set_declared_dependencies()
+    package.set_declared_extras_dependencies()
+
+    names = get_requirements_names_for_extra(package.imports, extra='extra')
+    assert 'setuptools' not in names
+
+
+def test_multiple_extras(minimal_structure):
+    path, package_name = minimal_structure
+    requires_file_path = os.path.join(
+        path,
+        '{0}.egg-info'.format(package_name),
+        'requires.txt',
+    )
+    with open(requires_file_path, 'w') as requires:
+        requires.write('\n'.join([
+            'setuptools',
+            '',
+            '[extra]',
+            'my_package',
+            'my_other_package',
+            ''
+            '[second]',
+            'just',
+            'laughs'
+        ]))
+
+    package = Package(path)
+    package.set_declared_extras_dependencies()
+
+    extras_names = get_extras_requirements_names(package.imports)
+    assert len(extras_names) == 2
+    assert 'second' in extras_names
+    assert 'extra' in extras_names

--- a/z3c/dependencychecker/tests/test_package.py
+++ b/z3c/dependencychecker/tests/test_package.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from z3c.dependencychecker.package import Package
+from z3c.dependencychecker.package import PackageMetadata
+
+
+def test_package_has_metadata(minimal_structure):
+    path, package_name = minimal_structure
+    package = Package(path)
+
+    assert bool(getattr(package, 'metadata', False))
+    assert isinstance(package.metadata, PackageMetadata)

--- a/z3c/dependencychecker/tests/test_package.py
+++ b/z3c/dependencychecker/tests/test_package.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from z3c.dependencychecker.package import Package
 from z3c.dependencychecker.package import PackageMetadata
+from z3c.dependencychecker.tests.utils import get_requirements_names
+import os
 
 
 def test_package_has_metadata(minimal_structure):
@@ -9,3 +11,30 @@ def test_package_has_metadata(minimal_structure):
 
     assert bool(getattr(package, 'metadata', False))
     assert isinstance(package.metadata, PackageMetadata)
+
+
+def test_declared_dependencies(minimal_structure):
+    path, package_name = minimal_structure
+    package = Package(path)
+    package.set_declared_dependencies()
+
+    requirements = get_requirements_names(package.imports)
+    assert len(requirements) == 2
+    assert 'one' in requirements
+    assert 'two' in requirements
+
+
+def test_declared_dependencies_empty(minimal_structure):
+    path, package_name = minimal_structure
+    requires_file_path = os.path.join(
+        path,
+        '{0}.egg-info'.format(package_name),
+        'requires.txt',
+    )
+    with open(requires_file_path, 'w') as requires:
+        requires.write('')
+
+    package = Package(path)
+    package.set_declared_dependencies()
+
+    assert len(get_requirements_names(package.imports)) == 0

--- a/z3c/dependencychecker/tests/utils.py
+++ b/z3c/dependencychecker/tests/utils.py
@@ -26,3 +26,14 @@ def get_requirements_names(database):
         requirement.name
         for requirement in database._requirements
     ]
+
+
+def get_extras_requirements_names(database):
+    return database._extras_requirements.keys()
+
+
+def get_requirements_names_for_extra(database, extra=''):
+    return [
+        requirement.name
+        for requirement in database._extras_requirements[extra]
+    ]

--- a/z3c/dependencychecker/tests/utils.py
+++ b/z3c/dependencychecker/tests/utils.py
@@ -19,3 +19,10 @@ def write_source_file_at(
         new_file.write(source_code)
 
     return file_path
+
+
+def get_requirements_names(database):
+    return [
+        requirement.name
+        for requirement in database._requirements
+    ]


### PR DESCRIPTION
Next one then 🙂 

In this one two classes are added at once:

- Database: it keeps dependencies and imports information, now it is small, but it will grow quite a lot (maybe too much? on future pull requests)
- Package: serves as a middle ground between the PackageMetadata and the Database classes, maybe it is too small that should be merged somewhere? I still think it makes sense to keep it, small classes are usually nicer.

@reinout @mauritsvanrees I'm eagerly waiting your feedback 🙂 