### PR TITLE
Minor fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,14 @@ Changelog of z3c.dependencychecker
 - Small improvements to the debug logging (``-v/--verbose`` shows it).
   [reinout]
 
+- Remove unused parameter in DottedName.
+  [gforcada]
+
+- All imports found by DocFiles imports extractor are marked as test ones.
+  [gforcada]
+
+- Handle multiple dotted names found in a single ZCML parameter.
+  [gforcada]
 
 2.0 (2018-01-04)
 ----------------

--- a/z3c/dependencychecker/dotted_name.py
+++ b/z3c/dependencychecker/dotted_name.py
@@ -10,7 +10,6 @@ class DottedName(object):
         self,
         name,
         file_path=None,
-        line_number=None,
         is_test=False,
     ):
         self.name = name

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -157,24 +157,24 @@ class ZCMLFile(BaseModule):
             element_namespaced = self._build_namespaced_element(element)
             for node in tree.iter(element_namespaced):
                 for attrib in self.ELEMENTS[element]:
-                    dotted_name = self._extract_dotted_name(node, attrib)
-                    if dotted_name:
+                    for dotted_name in self._extract_dotted_name(node, attrib):
                         yield dotted_name
 
     def _extract_dotted_name(self, node, attr):
         if attr in node.keys():
-            dotted_name = node.get(attr)
-            if dotted_name.startswith('.'):
-                return
+            candidate_text = node.get(attr)
+            for dotted_name in candidate_text.split(' '):
+                if dotted_name.startswith('.'):
+                    continue
 
-            if dotted_name == '*':
-                return
+                if dotted_name == '*':
+                    continue
 
-            return DottedName(
-                dotted_name,
-                file_path=self.path,
-                is_test=self.testing,
-            )
+                yield DottedName(
+                    dotted_name,
+                    file_path=self.path,
+                    is_test=self.testing,
+                )
 
     @staticmethod
     def _build_namespaced_element(element):

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -377,6 +377,7 @@ class DocFiles(PythonDocstrings):
 
                     for node in ast.walk(tree):
                         for dotted_name in self._process_ast_node(node):
+                            dotted_name.is_test = True
                             yield dotted_name
 
 

--- a/z3c/dependencychecker/tests/test_modules_docfiles.py
+++ b/z3c/dependencychecker/tests/test_modules_docfiles.py
@@ -115,6 +115,19 @@ def test_code_found_details(tmpdir):
     assert dotted_names == ['zope.annotation', ]
 
 
+def test_always_testing(tmpdir):
+    temporal_file = write_source_file_at(
+        (tmpdir.strpath, ),
+        source_code='>>> import foo',
+        filename='file.rst'
+    )
+
+    doc_file = DocFiles(tmpdir.strpath, temporal_file)
+    dotted_names = [x for x in doc_file.scan()]
+    assert len(dotted_names) == 1
+    assert dotted_names[0].is_test
+
+
 def test_multiple_imports_same_line(tmpdir):
     dotted_names = _get_dependencies_on_file(
         tmpdir,

--- a/z3c/dependencychecker/tests/test_modules_zcml.py
+++ b/z3c/dependencychecker/tests/test_modules_zcml.py
@@ -18,6 +18,7 @@ ZCML_TEMPLATE = """
 INCLUDE = '<include package="my.package.include" />'
 ADAPTER_FACTORY = '<adapter factory="my.package.factory" />'
 ADAPTER_FOR = '<adapter for="my.package.for" />'
+ADAPTER_FOR_MULTIPLE = '<adapter for="my.package.for another.package.foo yet.another.one" />'  # noqa
 ADAPTER_PROVIDES = '<adapter provides="my.package.provides" />'
 UTILITY_COMPONENT = '<utility component="my.package.component" />'
 UTILITY_PROVIDES = '<utility provides="my.package.provides" />'
@@ -88,6 +89,18 @@ def test_adapter_for(tmpdir):
 def test_adapter_for_details(tmpdir):
     dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FOR)
     assert dotted_names == ['my.package.for', ]
+
+
+def test_adapter_for_multiple(tmpdir):
+    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FOR_MULTIPLE)
+    assert len(dotted_names) == 3
+
+
+def test_adapter_for_multiple_details(tmpdir):
+    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FOR_MULTIPLE)
+    assert 'my.package.for' in dotted_names
+    assert 'another.package.foo' in dotted_names
+    assert 'yet.another.one' in dotted_names
 
 
 def test_adapter_provides(tmpdir):

--- a/z3c/dependencychecker/tests/test_report.py
+++ b/z3c/dependencychecker/tests/test_report.py
@@ -51,7 +51,7 @@ def test_missing_requirements(capsys, minimal_structure):
     )
 
     package = Package(path)
-    package.analyze_package()
+    package.inspect()
     report = Report(package)
     report.missing_requirements()
     out, err = capsys.readouterr()
@@ -75,7 +75,7 @@ def test_missing_test_requirements(capsys, minimal_structure):
     )
 
     package = Package(path)
-    package.analyze_package()
+    package.inspect()
     report = Report(package)
     report.missing_test_requirements()
     out, err = capsys.readouterr()
@@ -94,8 +94,7 @@ def test_unneeded_requirements(capsys, minimal_structure):
     )
 
     package = Package(path)
-    package.set_declared_dependencies()
-    package.analyze_package()
+    package.inspect()
     report = Report(package)
     report.unneeded_requirements()
     out, err = capsys.readouterr()
@@ -119,8 +118,7 @@ def test_unneeded_test_requirements(capsys, minimal_structure):
     )
 
     package = Package(path)
-    package.set_declared_extras_dependencies()
-    package.analyze_package()
+    package.inspect()
     report = Report(package)
     report.unneeded_test_requirements()
     out, err = capsys.readouterr()
@@ -138,8 +136,7 @@ def test_unneeded_test_requirements_no_tests_requirements(
     path, package_name = minimal_structure
 
     package = Package(path)
-    package.set_declared_extras_dependencies()
-    package.analyze_package()
+    package.inspect()
     report = Report(package)
     report.unneeded_test_requirements()
     out, err = capsys.readouterr()
@@ -175,9 +172,7 @@ def test_requirements_that_should_be_test_requirements(
     )
 
     package = Package(path)
-    package.set_declared_dependencies()
-    package.set_declared_extras_dependencies()
-    package.analyze_package()
+    package.inspect()
     report = Report(package)
     report.requirements_that_should_be_test_requirements()
     out, err = capsys.readouterr()


### PR DESCRIPTION
While testing the code with packages I notices quite a few things, but as it was too late to merge them on the *right* pull request I kept them until #67 was merged.

Overview of the changes:
- minor cleanups
- handle ZCML with more than one DottedName on an attribute
- process requirements to strip the ``python-`` prefix as well as to turn dashes into underscores
- mark all DocFiles imports as being test ones, regardless of where they are in the package structure