### PR TITLE
WIP: pypi names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ Changelog of z3c.dependencychecker
 - Handle multiple dotted names found in a single ZCML parameter.
   [gforcada]
 
+- Process requirements' project names to remove the ``python-`` prefix,
+  turn all dashes into underscores as well.
+  This helps finding quite a lot of packages.
+  [gforcada]
+
 2.0 (2018-01-04)
 ----------------
 

--- a/z3c/dependencychecker/dotted_name.py
+++ b/z3c/dependencychecker/dotted_name.py
@@ -1,6 +1,16 @@
 # -*- coding: utf-8 -*-
 import hashlib
+import re
 from functools import total_ordering
+
+
+# some pypi packages' names have a prefix that is not part of the package
+# namespace
+# They can be safely removed
+PREFIXES = (
+    'python-',
+    'django-',
+)
 
 
 @total_ordering
@@ -24,8 +34,12 @@ class DottedName(object):
         """A requirement in this method's context is a
         pkg_resources.Requirement
         """
+        dotted_name = requirement.project_name
+        for prefix in PREFIXES:
+            dotted_name = re.sub(r'^{0}'.format(prefix), '', dotted_name)
+        dotted_name = dotted_name.replace('-', '_')
         return cls(
-            requirement.project_name,
+            dotted_name,
             file_path=file_path,
         )
 

--- a/z3c/dependencychecker/tests/test_dotted_name.py
+++ b/z3c/dependencychecker/tests/test_dotted_name.py
@@ -31,6 +31,56 @@ def test_requirement_constructor():
     assert obj.name == 'my.dotted.name'
 
 
+def test_requirement_constructor_python_prefix():
+    mock_object = mock.MagicMock()
+    mock_property = mock.PropertyMock(return_value='python-dateutil')
+    type(mock_object).project_name = mock_property
+
+    obj = DottedName.from_requirement(mock_object)
+
+    assert obj.name == 'dateutil'
+
+
+def test_requirement_constructor_keep_python_if_no_prefix():
+    mock_object = mock.MagicMock()
+    mock_property = mock.PropertyMock(return_value='one-python-dateutil')
+    type(mock_object).project_name = mock_property
+
+    obj = DottedName.from_requirement(mock_object)
+
+    assert obj.name == 'one_python_dateutil'
+
+
+def test_requirement_constructor_django_prefix():
+    mock_object = mock.MagicMock()
+    mock_property = mock.PropertyMock(return_value='django-dateutil')
+    type(mock_object).project_name = mock_property
+
+    obj = DottedName.from_requirement(mock_object)
+
+    assert obj.name == 'dateutil'
+
+
+def test_requirement_constructor_keep_django_if_no_prefix():
+    mock_object = mock.MagicMock()
+    mock_property = mock.PropertyMock(return_value='one-django-dateutil')
+    type(mock_object).project_name = mock_property
+
+    obj = DottedName.from_requirement(mock_object)
+
+    assert obj.name == 'one_django_dateutil'
+
+
+def test_requirement_constructor_change_to_underscores():
+    mock_object = mock.MagicMock()
+    mock_property = mock.PropertyMock(return_value='my-fancy-package')
+    type(mock_object).project_name = mock_property
+
+    obj = DottedName.from_requirement(mock_object)
+
+    assert obj.name == 'my_fancy_package'
+
+
 def test_requirement_constructor_with_path():
     mock_object = mock.MagicMock()
     mock_property = mock.PropertyMock(return_value='my.dotted.name')


### PR DESCRIPTION
*Only merge this one after #70 is merged, as it contains its commits as well.*

Continuing the discussion from #70:

When I was looking at that part of the code that tried to import a dotted name and from there find out to which package belonged, I thought that was really clever, but then this means that you should have that package ``pip install``ed in your environment where you are actually running z3c.dependencychecker, which is far from optimal.

IMHO we should give a go at #41 I have a half baked branch where I'm reading pyproject.toml to get the metadependencies and from there override the reports. We could as well let the users specify which dotted names belong to a package.

With this we would allow a completely clean and isolated virtual environment for z3c.dependencychecker, without having to install any extra dependencies.

Would that be ok with you? @reinout @mauritsvanrees 