### PR TITLE
[performance] Filter packages when adding them

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Changelog of z3c.dependencychecker
 - Use properties to make code more pythonic.
   [gforcada]
 
+- Filter imports when adding them to the database, rather than on each report.
+  [gforcada]
+
 2.0 (2018-01-04)
 ----------------
 

--- a/z3c/dependencychecker/tests/test_imports_database.py
+++ b/z3c/dependencychecker/tests/test_imports_database.py
@@ -123,6 +123,7 @@ def test_no_used_imports():
 
 def test_add_used_imports():
     database = ImportsDatabase()
+    database.own_dotted_name = DottedName('something-else')
     database.add_imports([
         DottedName('one'),
         DottedName('two'),

--- a/z3c/dependencychecker/tests/utils.py
+++ b/z3c/dependencychecker/tests/utils.py
@@ -5,7 +5,7 @@ import os
 def write_source_file_at(
     path_parts,
     filename='test.py',
-    source_code='import one',
+    source_code='import unknown.dependency',
 ):
     folder_path = os.path.join(*path_parts)
 


### PR DESCRIPTION
There are some filters that are will be always applied,

so rather than applying them at each report, apply them when they are added to the database.