### PR TITLE
Ignore relative imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog of z3c.dependencychecker
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Ignore relative imports (i.e. from . import foo).
+  [gforcada]
 
 2.1.1 (2018-03-10)
 ------------------

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -103,6 +103,8 @@ class PythonModule(BaseModule):
                 )
 
         elif isinstance(node, ast.ImportFrom):
+            if self._is_relative_import(node):
+                return
             for name in node.names:
                 if name.name == '*':
                     dotted_name = node.module
@@ -113,6 +115,10 @@ class PythonModule(BaseModule):
                     file_path=self.path,
                     is_test=self.testing,
                 )
+
+    @staticmethod
+    def _is_relative_import(import_node):
+        return import_node.level > 0
 
 
 class ZCMLFile(BaseModule):

--- a/z3c/dependencychecker/tests/test_modules_python.py
+++ b/z3c/dependencychecker/tests/test_modules_python.py
@@ -2,6 +2,7 @@
 from z3c.dependencychecker.modules import PythonModule
 from z3c.dependencychecker.tests.utils import write_source_file_at
 import os
+import pytest
 import tempfile
 
 
@@ -15,6 +16,9 @@ FROM_IMPORT_MULTIPLE = 'from foo import bar, ber'
 FROM_IMPORT_AS = 'from foo import bar as ber'
 FROM_IMPORT_AS_MULTIPLE = 'from foo import bar as ber, boo as bla'
 FROM_IMPORT_ASTERISK = 'from os import *'
+FROM_IMPORT_DOT = 'from . import something'
+FROM_IMPORT_DOT_DOT = 'from .. import something'
+FROM_IMPORT_DOT_RELATIVE = 'from .local import something'
 
 
 def _get_imports_of_python_module(folder, source):
@@ -165,6 +169,19 @@ def test_import_asterisk(tmpdir):
 def test_import_asterisk_details(tmpdir):
     dotted_names = _get_imports_of_python_module(tmpdir, FROM_IMPORT_ASTERISK)
     assert dotted_names == ['os', ]
+
+
+@pytest.mark.parametrize(
+    'statement',
+    [
+        FROM_IMPORT_DOT,
+        FROM_IMPORT_DOT_DOT,
+        FROM_IMPORT_DOT_RELATIVE,
+    ]
+)
+def test_ignore_local_imports(statement, tmpdir):
+    dotted_names = _get_imports_of_python_module(tmpdir, statement)
+    assert len(dotted_names) == 0
 
 
 def test_from_import_as_multiple(tmpdir):


### PR DESCRIPTION
It seems that we forgot to ignore those :-)

i.e. imports like `` from . import foo`` or ``from .local import foo``.
