### PR TITLE
Ignore packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Changelog of z3c.dependencychecker
 - Ignore relative imports (i.e. from . import foo).
   [gforcada]
 
+- Added ``ignore-packages`` config option to totally ignore one or more packages in the reports
+  (whether unused imports or unneeded dependencies).
+  Handy for soft dependencies.
+  [gforcada]
+
 2.1.1 (2018-03-10)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,29 @@ Add a `pyproject.toml` file on the root of your project with the following conte
 
 z3c.dependencychecker will read this information and use it on its reports.
 
+Ignore packages
+---------------
+
+Sometimes you need to add a package in `setup.py` although you are not importing it directly,
+but maybe is an extra dependency of one of your dependencies,
+or your package has a soft dependency on a package,
+and as a soft dependency it is not mandatory to install it always.
+
+`z3c.dependencychecker` would complain in both cases.
+It would report that a dependency is not needed,
+or that a missing package is not listed on the package requirements.
+
+Fortunately, `z3c.dependencychecker` also has a solution for it.
+
+Add a `pyproject.toml` file on the root of your project with the following content:
+
+    [tool.dependencychecker]
+    ignore-packages = ['one-package', 'another.package' ]
+
+`z3c.dependencychecker` will totally ignore those packages in its reports,
+whether they're requirements that appear to be unused,
+or requirements that appear to be missing.
+
 Credits
 -------
 

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -21,6 +21,7 @@ class ImportsDatabase(object):
         self.imports_used = []
         self.user_mappings = {}
         self.reverse_user_mappings = {}
+        self.ignored_packages = set()
         self.own_dotted_name = None
 
     def add_requirements(self, requirements):
@@ -82,6 +83,12 @@ class ImportsDatabase(object):
 
         for single_package in packages_provided:
             self.reverse_user_mappings[single_package] = package
+
+    def add_ignored_packages(self, packages):
+        self.ignored_packages = set([
+            DottedName(package)
+            for package in packages
+        ])
 
     def _all_requirements(self):
         all_requirements = self._requirements.copy()

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -101,6 +101,7 @@ class ImportsDatabase(object):
         filters = (
             self._filter_out_testing_imports,
             self._filter_out_requirements,
+            self._filter_out_ignored_imports,
         )
         missing = self._apply_filters(self.imports_used, filters)
         unique_imports = self._get_unique_imports(imports_list=missing)
@@ -112,6 +113,7 @@ class ImportsDatabase(object):
             self._filter_out_only_testing_imports,
             self._filter_out_requirements,
             self._filter_out_test_requirements,
+            self._filter_out_ignored_imports,
         )
         missing = self._apply_filters(self.imports_used, filters)
         unique_imports = self._get_unique_imports(imports_list=missing)
@@ -129,6 +131,7 @@ class ImportsDatabase(object):
             self._filter_out_known_packages,
             self._filter_out_python_standard_library,
             self._filter_out_used_imports,
+            self._filter_out_ignored_imports,
         )
         unneeded = self._apply_filters(all_but_test_requirements, filters)
         unique_imports = self._get_unique_imports(imports_list=unneeded)
@@ -166,9 +169,14 @@ class ImportsDatabase(object):
                 testing_imports,
             )
         ]
-        unique = self._get_unique_imports(
-            imports_list=should_be_test_requirements,
+        filters = (
+            self._filter_out_ignored_imports,
         )
+        skip_ignored = self._apply_filters(
+            should_be_test_requirements,
+            filters,
+        )
+        unique = self._get_unique_imports(imports_list=skip_ignored)
         return unique
 
     def get_unneeded_test_requirements(self):
@@ -180,6 +188,7 @@ class ImportsDatabase(object):
             self._filter_out_known_packages,
             self._filter_out_python_standard_library,
             self._filter_out_used_imports,
+            self._filter_out_ignored_imports,
         )
         unneeded = self._apply_filters(test_requirements, filters)
         unique_imports = self._get_unique_imports(imports_list=unneeded)
@@ -223,6 +232,12 @@ class ImportsDatabase(object):
         return self._discard_if_found_obj_in_list(
             dotted_name,
             self.imports_used,
+        )
+
+    def _filter_out_ignored_imports(self, dotted_name):
+        return self._discard_if_found_obj_in_list(
+            dotted_name,
+            self.ignored_packages,
         )
 
     def _filter_out_known_packages(self, dotted_name):

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -225,7 +225,15 @@ class Package(object):
         """
         config = self._load_user_config()
         for package, packages_provided in config.items():
-            if isinstance(packages_provided, list):
+            if package == 'ignore-packages':
+                if isinstance(packages_provided, list):
+                    self.imports.add_ignored_packages(packages_provided)
+                else:
+                    logger.warning(
+                        'ignore-packages key in pyproject.toml needs to '
+                        'be a list, even for a single package to be ignored.'
+                    )
+            elif isinstance(packages_provided, list):
                 self.imports.add_user_mapping(package, packages_provided)
 
     def analyze_package(self):

--- a/z3c/dependencychecker/tests/test_report.py
+++ b/z3c/dependencychecker/tests/test_report.py
@@ -94,6 +94,35 @@ def test_missing_requirements_with_user_mapping(capsys, minimal_structure):
     assert 'Zope2' not in out
 
 
+def test_missing_requirements_with_ignored_packages(capsys, minimal_structure):
+    path, package_name = minimal_structure
+    write_source_file_at(
+        (path, package_name),
+        '__init__.py',
+        'import Products.Five.browser.views.BrowserView'
+    )
+    write_source_file_at(
+        (path, ),
+        'pyproject.toml',
+        '\n'.join([
+            '[tool.dependencychecker]',
+            'ignore-packages = ["Four", "Products.Five", "Three" ]',
+        ]),
+    )
+
+    package = Package(path)
+    package.inspect()
+    report = Report(package)
+    report.missing_requirements()
+    out, err = capsys.readouterr()
+
+    assert 'Missing requirements\n' \
+           '====================' not in out
+    assert 'Products.Five' not in out
+    assert 'Four' not in out
+    assert 'Three' not in out
+
+
 def test_missing_test_requirements(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
@@ -205,6 +234,42 @@ def test_missing_test_requirements_with_user_mapping_on_test_extra(
     assert 'Zope2' not in out
 
 
+def test_missing_test_requirements_with_ignored_packages(
+    capsys,
+    minimal_structure
+):
+    path, package_name = minimal_structure
+    write_source_file_at(
+        (path, package_name),
+        '__init__.py',
+        '',
+    )
+    write_source_file_at(
+        (path, package_name, 'tests'),
+        '__init__.py',
+        'import Products.Five.browser.views.BrowserView'
+    )
+    write_source_file_at(
+        (path, ),
+        'pyproject.toml',
+        '\n'.join([
+            '[tool.dependencychecker]',
+            'ignore-packages = ["Products.Five" ]',
+        ]),
+    )
+
+    package = Package(path)
+    package.inspect()
+    report = Report(package)
+    report.missing_test_requirements()
+    out, err = capsys.readouterr()
+
+    assert '' == out
+    assert 'Missing requirements\n' \
+           '====================' not in out
+    assert 'Products.Five' not in out
+
+
 def test_unneeded_requirements(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
@@ -222,6 +287,36 @@ def test_unneeded_requirements(capsys, minimal_structure):
     assert 'Unneeded requirements\n' \
            '=====================' in out
     assert 'one' in out
+    assert 'two' in out
+
+
+def test_unneeded_requirements_with_ignored_packages(
+        capsys,
+        minimal_structure):
+    path, package_name = minimal_structure
+    write_source_file_at(
+        (path, package_name),
+        '__init__.py',
+        'import this.package',
+    )
+    write_source_file_at(
+        (path, ),
+        'pyproject.toml',
+        '\n'.join([
+            '[tool.dependencychecker]',
+            'ignore-packages = ["one" ]',
+        ]),
+    )
+
+    package = Package(path)
+    package.inspect()
+    report = Report(package)
+    report.unneeded_requirements()
+    out, err = capsys.readouterr()
+
+    assert 'Unneeded requirements\n' \
+           '=====================' in out
+    assert 'one' not in out
     assert 'two' in out
 
 
@@ -247,6 +342,41 @@ def test_unneeded_test_requirements(capsys, minimal_structure):
            '==========================' in out
     assert 'pytest' in out
     assert 'mock' in out
+
+
+def test_unneeded_test_requirements_with_ignore_packages(
+    capsys,
+    minimal_structure
+):
+    path, package_name = minimal_structure
+    write_source_file_at(
+        (path, package_name + '.egg-info'),
+        'requires.txt',
+        '\n'.join([
+            '[test]',
+            'pytest',
+            'mock',
+        ]),
+    )
+    write_source_file_at(
+        (path, ),
+        'pyproject.toml',
+        '\n'.join([
+            '[tool.dependencychecker]',
+            'ignore-packages = ["mock" ]',
+        ]),
+    )
+
+    package = Package(path)
+    package.inspect()
+    report = Report(package)
+    report.unneeded_test_requirements()
+    out, err = capsys.readouterr()
+
+    assert 'Unneeded test requirements\n' \
+           '==========================' in out
+    assert 'pytest' in out
+    assert 'mock' not in out
 
 
 def test_unneeded_test_requirements_no_tests_requirements(
@@ -300,6 +430,57 @@ def test_requirements_that_should_be_test_requirements(
     assert 'Requirements that should be test requirements\n' \
            '=============================================' in out
     assert 'two' in out
+
+
+def test_requirements_that_should_be_test_requirements_with_ignored_packages(
+    capsys,
+    minimal_structure,
+):
+    path, package_name = minimal_structure
+    write_source_file_at(
+        (path, package_name),
+        '__init__.py',
+        'import one',
+    )
+    write_source_file_at(
+        (path, package_name, 'tests'),
+        '__init__.py',
+        '\n'.join([
+            'import two',
+            'import three',
+        ])
+    )
+    write_source_file_at(
+        (path, package_name + '.egg-info'),
+        'requires.txt',
+        '\n'.join([
+            'one',
+            'two',
+            'three',
+            '[test]',
+            'pytest',
+            'mock',
+        ]),
+    )
+    write_source_file_at(
+        (path, ),
+        'pyproject.toml',
+        '\n'.join([
+            '[tool.dependencychecker]',
+            'ignore-packages = ["two" ]',
+        ]),
+    )
+
+    package = Package(path)
+    package.inspect()
+    report = Report(package)
+    report.requirements_that_should_be_test_requirements()
+    out, err = capsys.readouterr()
+
+    assert 'Requirements that should be test requirements\n' \
+           '=============================================' in out
+    assert 'three' in out
+    assert 'two' not in out
 
 
 def test_print_notice(capsys, minimal_structure):


### PR DESCRIPTION
And with this, I think we have the last building block.

When I've been trying to use it on Plone code bases this was the last missing piece that ``z3c.dependencychecker`` needed to be 100% usable.