### PR TITLE
Fix ZCML parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog of z3c.dependencychecker
 2.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Fix ZCML parser to discard empty strings.
+  [gforcada]
 
 2.2 (2018-06-19)
 ----------------

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -170,7 +170,7 @@ class ZCMLFile(BaseModule):
         if attr in node.keys():
             candidate_text = node.get(attr)
             for dotted_name in candidate_text.split(' '):
-                if dotted_name.startswith('.'):
+                if not dotted_name or dotted_name.startswith('.'):
                     continue
 
                 if dotted_name == '*':

--- a/z3c/dependencychecker/tests/test_modules_zcml.py
+++ b/z3c/dependencychecker/tests/test_modules_zcml.py
@@ -26,6 +26,8 @@ BROWSER_PAGE_CLASS = '<browser:page class="my.package.class" />'
 BROWSER_PAGE_FOR = '<browser:page for="my.package.for" />'
 BROWSER_PAGE_LAYER = '<browser:page layer="my.package.layer" />'
 SUBSCRIBER_FOR = '<subscriber for="my.package.for" />'
+SUBSCRIBER_FOR_MULTIPLE = '<subscriber for="my.package.for' \
+                 '                 another.package" />'
 SUBSCRIBER_HANDLER = '<subscriber handler="my.package.handler" />'
 SECURITYPOLICY_COMPONENT = '<securityPolicy component="my.package.component" />'  # noqa
 GS_REGISTERPROFILE_PROVIDES = '<genericsetup:registerProfile provides="my.package.provides" />'  # noqa
@@ -171,6 +173,19 @@ def test_subscriber_for(tmpdir):
 def test_subscriber_for_details(tmpdir):
     dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_FOR)
     assert dotted_names == ['my.package.for', ]
+
+
+def test_subscriber_for_multiple(tmpdir):
+    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_FOR_MULTIPLE)
+    assert len(dotted_names) == 2
+
+
+def test_subscriber_for_multiple_details(tmpdir):
+    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_FOR_MULTIPLE)
+    assert dotted_names == [
+        'my.package.for',
+        'another.package',
+    ]
 
 
 def test_subscriber_handler(tmpdir):


### PR DESCRIPTION
As it was splitting a string into chunks, it was not checking that one
of these chunks could be empty.