### PR TITLE
Fix rendering of long description

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog of z3c.dependencychecker
 2.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Fix rendering of long description in pypi.
+  [gforcada]
 
 2.4 (2018-06-30)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Quality Assurance',
     ],
-    keywords=[
-        'dependencies',
-        'requirements',
-        'missing',
-        'imports',
-    ],
+    keywords='dependencies requirements missing imports',
     author='Reinout van Rees',
     author_email='reinout@vanrees.org',
     url='https://github.com/reinout/z3c.dependencychecker',


### PR DESCRIPTION
I'm actually not even sure that it will fix it, only an actual release, a pre-release one?, would actually verify that.
But comparing our setup.py with other projects' setup.py I noticed that the ``keywords`` argument is a string rather than a list, so maybe changing that back fixes it.

Actually if you look at the pypi page of z3c.dependencychecker you see that at the very beginning it has some data that is not even on the README... I guess it should be on the left column but, maybe, the keywords-as-a-list breaks its rendering...