### PR TITLE
.rst formatting fixes in the long description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,13 +50,15 @@ It checks the following locations:
 User mappings
 -------------
 
-Some packages available on pypi have a different name than the import statement needed to use them,
-i.e. `python-dateutil` is imported as `import dateutil`.
-Others provide more than one package, i.e `Zope2` provides several packages like `Products.Five` or `Products.OFSP`.
+Some packages available on pypi have a different name than the import
+statement needed to use them, i.e. `python-dateutil` is imported as `import
+dateutil`.  Others provide more than one package, i.e `Zope2` provides several
+packages like `Products.Five` or `Products.OFSP`.
 
 For those cases, z3c.dependencychecker has a solution: user mappings.
 
-Add a `pyproject.toml` file on the root of your project with the following content:
+Add a `pyproject.toml` file on the root of your project with the following
+content::
 
     [tool.dependencychecker]
     python-dateutil = ['dateutil']
@@ -67,25 +69,26 @@ z3c.dependencychecker will read this information and use it on its reports.
 Ignore packages
 ---------------
 
-Sometimes you need to add a package in `setup.py` although you are not importing it directly,
-but maybe is an extra dependency of one of your dependencies,
-or your package has a soft dependency on a package,
-and as a soft dependency it is not mandatory to install it always.
+Sometimes you need to add a package in `setup.py` although you are not
+importing it directly, but maybe is an extra dependency of one of your
+dependencies, or your package has a soft dependency on a package, and as a
+soft dependency it is not mandatory to install it always.
 
-`z3c.dependencychecker` would complain in both cases.
-It would report that a dependency is not needed,
-or that a missing package is not listed on the package requirements.
+`z3c.dependencychecker` would complain in both cases. It would report that a
+dependency is not needed, or that a missing package is not listed on the
+package requirements.
 
 Fortunately, `z3c.dependencychecker` also has a solution for it.
 
-Add a `pyproject.toml` file on the root of your project with the following content:
+Add a `pyproject.toml` file on the root of your project with the following
+content::
 
     [tool.dependencychecker]
     ignore-packages = ['one-package', 'another.package' ]
 
 `z3c.dependencychecker` will totally ignore those packages in its reports,
-whether they're requirements that appear to be unused,
-or requirements that appear to be missing.
+whether they're requirements that appear to be unused, or requirements that
+appear to be missing.
 
 Credits
 -------

--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,9 @@ copy from `lovely.recipe's checkout
 
 - Quite some fixes from `Jonas Baumann <https://github.com/jone>`_.
 
-- Many updates to work well with modern Plone versions by `Gil Forcada
-  Codinachs <http://gil.badall.net/>`.
+- Many updates (basically: rewriting the entire codebase to work with AST!) to
+  work well with modern Plone versions by `Gil Forcada Codinachs
+  <http://gil.badall.net/>`.
 
 
 Source code, forking and reporting bugs

--- a/z3c/dependencychecker/USAGE.rst
+++ b/z3c/dependencychecker/USAGE.rst
@@ -21,7 +21,7 @@ By default, it looks in the ``src/`` directory for your sources.
 Alternatively, you can specify a start directory yourself, for instance
 ``'.'`` if there's no ``src/`` directory.
 
-We have a sample project in a temp directory:
+We have a sample project in a temp directory::
 
     >>> sample1_dir
     '/TESTTEMP/sample1'
@@ -30,7 +30,7 @@ We have a sample project in a temp directory:
     src
 
 For our test, we call the main() method, just like the ``dependencychecker``
-script would:
+script would::
 
     >>> import os
     >>> os.chdir(sample1_dir)


### PR DESCRIPTION
Mostly replacing `:` with `::` so that the code examples are formatted properly.

Also limited the line lengths a bit. And mentioned the AST :-)