### PR TITLE
[PackageMetadata] Check more locations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog of z3c.dependencychecker
 2.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Check in every top level folder if the .egg-info folder is in them.
+  [gforcada]
 
 2.4.4 (2018-07-04)
 ------------------

--- a/z3c/dependencychecker/USAGE.rst
+++ b/z3c/dependencychecker/USAGE.rst
@@ -17,9 +17,10 @@ Usage
 Run the ``dependencychecker`` or ``bin/dependencychecker`` script from your
 project's root folder and it will report on your dependencies.
 
-By default, it looks in the ``src/`` directory for your sources.
-Alternatively, you can specify a start directory yourself, for instance
-``'.'`` if there's no ``src/`` directory.
+You must have installed your project, as z3c.dependencychecker needs the
+``YOURPROJECT.egg-info`` directory that setuptools generates. It looks for
+that directory in the root folder and in the direct subdirectory (like
+``src/`` or ``plone/``).
 
 We have a sample project in a temp directory::
 

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -47,10 +47,18 @@ class PackageMetadata(object):
     @cached_property
     def package_dir(self):
         """Check where the .egg-info is located"""
-        try_paths = (
-            self.distribution_root,
-            os.path.join(self.distribution_root, 'src', )
-        )
+        try_paths = [
+            self.distribution_root
+        ]
+        top_level_elements = [
+            os.path.join(self.distribution_root, folder)
+            for folder in os.listdir(self.distribution_root)
+        ]
+        try_paths += [
+            folder
+            for folder in top_level_elements
+            if os.path.isdir(folder)
+        ]
         for path in try_paths:
             folder_found = self._find_egg_info_in_folder(path)
             if folder_found:
@@ -65,16 +73,8 @@ class PackageMetadata(object):
 
     @staticmethod
     def _find_egg_info_in_folder(path):
-        if not os.path.exists(path):
-            logger.error(
-                'Folder %s does not exist',
-                path,
-            )
-            sys.exit(1)
-
         with change_dir(path):
             results = glob.glob('*.egg-info')
-
         return results
 
     @cached_property

--- a/z3c/dependencychecker/tests/test_package_metadata.py
+++ b/z3c/dependencychecker/tests/test_package_metadata.py
@@ -64,6 +64,32 @@ def test_package_dir_on_src_folder(minimal_structure):
     assert metadata.package_dir == src_folder
 
 
+def test_package_dir_on_another_folder(minimal_structure):
+    def move_top_level_to_folder(package_path, egg_folder, folder_path):
+        top_level_file_path = os.path.join(
+            egg_folder,
+            'top_level.txt'
+        )
+        with open(top_level_file_path) as top_level_file:
+            top_level_folder = top_level_file.read().strip()
+
+        top_level_sources = os.path.join(package_path, top_level_folder)
+
+        shutil.move(top_level_sources, folder_path)
+        shutil.move(egg_folder, folder_path)
+
+    path, package_name = minimal_structure
+
+    egg_info_folder = os.path.join(path, '{0}.egg-info'.format(package_name))
+    folder_path = os.path.join(path, 'somewhere')
+
+    move_top_level_to_folder(path, egg_info_folder, folder_path)
+
+    metadata = PackageMetadata(path)
+
+    assert metadata.package_dir == folder_path
+
+
 def test_no_package_dir_found(minimal_structure):
     path, package_name = minimal_structure
     shutil.rmtree(os.path.join(path, '{0}.egg-info'.format(package_name)))


### PR DESCRIPTION
The world is vast, and the top level folder and ``src`` is not enough.

Specially in projects like Plone where quite a lot of packages have
``plone`` as their package_dir.

This commit makes ``package_dir`` search to look at all top level
folders.