### PR TITLE
User mappings everywhere

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,13 @@ Changelog of z3c.dependencychecker
 2.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use the user mappings on the remaining reports:
 
+  - unneeded dependencies
+  - unneeded test dependencies
+  - dependencies that should be test dependencies
+
+  [gforcada]
 
 2.5.1 (2018-07-06)
 ------------------

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -132,6 +132,7 @@ class ImportsDatabase(object):
             self._filter_out_python_standard_library,
             self._filter_out_used_imports,
             self._filter_out_ignored_imports,
+            self._filter_out_mappings,
         )
         unneeded = self._apply_filters(all_but_test_requirements, filters)
         unique_imports = self._get_unique_imports(imports_list=unneeded)
@@ -233,6 +234,25 @@ class ImportsDatabase(object):
             dotted_name,
             self.imports_used,
         )
+
+    def _filter_out_mappings(self, meta_package):
+        """Filter meta packages
+
+        If it is not a meta package, let it continue the filtering.
+
+        If it is a meta package, check if any of the packages it provides is
+        used. If any of them it is, then filter it.
+        """
+        if meta_package not in self.user_mappings.keys():
+            return True
+
+        for dotted_name in self.user_mappings[meta_package]:
+            if not self._discard_if_found_obj_in_list(
+                    dotted_name,
+                    self.imports_used):
+                return False
+
+        return True
 
     def _filter_out_ignored_imports(self, dotted_name):
         return self._discard_if_found_obj_in_list(

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -162,12 +162,19 @@ class ImportsDatabase(object):
             self.imports_used,
             testing_filters,
         )
+        complete_test_imports = []
+        for test_import in testing_imports:
+            if test_import in self.reverse_user_mappings:
+                meta_package = self.reverse_user_mappings[test_import]
+                complete_test_imports.append(meta_package)
+                continue
+            complete_test_imports.append(test_import)
         should_be_test_requirements = [
             requirement
             for requirement in requirements_not_used
             if not self._discard_if_found_obj_in_list(
                 requirement,
-                testing_imports,
+                complete_test_imports,
             )
         ]
         filters = (

--- a/z3c/dependencychecker/tests/test_report.py
+++ b/z3c/dependencychecker/tests/test_report.py
@@ -320,6 +320,84 @@ def test_unneeded_requirements_with_ignored_packages(
     assert 'two' in out
 
 
+def test_unneeded_requirements_with_user_mapping(
+        capsys,
+        minimal_structure):
+    path, package_name = minimal_structure
+    write_source_file_at(
+        (path, package_name),
+        '__init__.py',
+        'from BTrees import Tree',
+    )
+    write_source_file_at(
+        (path, ),
+        'pyproject.toml',
+        '\n'.join([
+            '[tool.dependencychecker]',
+            '"ZODB3" = ["BTrees" ]',
+        ]),
+    )
+    write_source_file_at(
+        (path, '{0}.egg-info'.format(package_name), ),
+        'requires.txt',
+        '\n'.join([
+            'ZODB3',
+            'setuptools',
+            'one',
+        ]),
+    )
+
+    package = Package(path)
+    package.inspect()
+    report = Report(package)
+    report.unneeded_requirements()
+    out, err = capsys.readouterr()
+
+    assert 'Unneeded requirements\n' \
+           '=====================' in out
+    assert 'ZODB3' not in out
+    assert 'one' in out
+
+
+def test_unneeded_requirements_with_user_mapping2(
+        capsys,
+        minimal_structure):
+    path, package_name = minimal_structure
+    write_source_file_at(
+        (path, package_name),
+        '__init__.py',
+        'from Plone import Tree',
+    )
+    write_source_file_at(
+        (path, ),
+        'pyproject.toml',
+        '\n'.join([
+            '[tool.dependencychecker]',
+            '"ZODB3" = ["BTrees" ]',
+        ]),
+    )
+    write_source_file_at(
+        (path, '{0}.egg-info'.format(package_name), ),
+        'requires.txt',
+        '\n'.join([
+            'ZODB3',
+            'setuptools',
+            'one',
+        ]),
+    )
+
+    package = Package(path)
+    package.inspect()
+    report = Report(package)
+    report.unneeded_requirements()
+    out, err = capsys.readouterr()
+
+    assert 'Unneeded requirements\n' \
+           '=====================' in out
+    assert 'ZODB3' in out
+    assert 'one' in out
+
+
 def test_unneeded_test_requirements(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(


### PR DESCRIPTION
I was too lazy when I added user mappings, that I only added it to the first two reports (missing dependencies and missing test dependencies).

But while trying to fix a package in Plone I was already in the need of using user mappings for the other three reports.

So, finally, here it is.