### PR TITLE
[modules] Consider docstrings imports as tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog of z3c.dependencychecker
 2.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Always consider imports in python docstrings to be test dependencies.
+  [gforcada]
 
 2.5.1 (2018-07-06)
 ------------------

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -326,6 +326,7 @@ class PythonDocstrings(PythonModule):
 
                 for node in ast.walk(tree):
                     for dotted_name in self._process_ast_node(node):
+                        dotted_name.is_test = True
                         yield dotted_name
 
     @staticmethod


### PR DESCRIPTION
Any import in a docstring is not used when running the code in a normal
mode, but rather only when called with some special tools, like a test
runner.
    
Thus, always consider the imports done there to be test imports.
