### PR TITLE
Fix report

### DIFF
--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -146,12 +146,20 @@ class ImportsDatabase(object):
             self.imports_used,
             non_testing_filters,
         )
+        complete_non_testing_imports = []
+        for non_test_import in non_testing_imports:
+            if non_test_import in self.reverse_user_mappings:
+                meta_package = self.reverse_user_mappings[non_test_import]
+                complete_non_testing_imports.append(meta_package)
+                continue
+            complete_non_testing_imports.append(non_test_import)
+
         requirements_not_used = [
             requirement
             for requirement in self._requirements
             if self._discard_if_found_obj_in_list(
                 requirement,
-                non_testing_imports,
+                complete_non_testing_imports,
             )
         ]
         testing_filters = (


### PR DESCRIPTION
Test and fix the 'requirement should be test requirement' report to
account for imports of a user mappings used in both regular and test
imports that the report wrongly considered that the user mapping should
be downgraded to a test import only.

That was a hard nut to crack :sweat_smile: Thanks to the Plone PLIP https://github.com/plone/Products.CMFPlone/issues/2448 I guess we will find, hopefully not so many, some more bugs.

Fortunately, as the test suite is quite good, specially the ``test_report.py``, we could eventually, refactor the reports to make them readable, with a high degree of confidence.