### PR TITLE
Ignore certain folders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,15 @@ Changelog of z3c.dependencychecker
 2.11 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Ignore `node_modules` and `__pycache__` folders
+  when scanning for files with dependencies.
+  [gforcada]
 
 2.10 (2023-01-30)
 -----------------
 
 - Do not ignore `Zope` user mappings, fixes previous release.
-  [gforcada
+  [gforcada]
 
 2.9 (2023-01-23)
 ----------------

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -27,6 +27,8 @@ TEST_IN_PATH_REGEX = re.compile(TEST_REGEX, re.VERBOSE)
 
 logger = logging.getLogger(__name__)
 
+FOLDERS_TO_IGNORE = ("node_modules", "__pycache__")
+
 
 class BaseModule:
     def __init__(self, package_path, full_path):
@@ -146,7 +148,8 @@ class ZCMLFile(BaseModule):
         if top_dir.endswith(".py"):
             return
 
-        for path, _folders, filenames in os.walk(top_dir):
+        for path, folders, filenames in os.walk(top_dir):
+            folders[:] = [d for d in folders if d not in FOLDERS_TO_IGNORE]
             for filename in filenames:
                 if filename.endswith(".zcml"):
                     yield cls(
@@ -210,7 +213,8 @@ class FTIFile(BaseModule):
         if top_dir.endswith(".py"):
             return
 
-        for path, _folders, filenames in os.walk(top_dir):
+        for path, folders, filenames in os.walk(top_dir):
+            folders[:] = [d for d in folders if d not in FOLDERS_TO_IGNORE]
             for filename in filenames:
                 if filename.endswith(".xml") and cls.TYPES_FOLDER in path:
                     yield cls(
@@ -260,7 +264,8 @@ class GSMetadata(BaseModule):
         if top_dir.endswith(".py"):
             return
 
-        for path, _folders, filenames in os.walk(top_dir):
+        for path, folders, filenames in os.walk(top_dir):
+            folders[:] = [d for d in folders if d not in FOLDERS_TO_IGNORE]
             for filename in filenames:
                 if filename == "metadata.xml":
                     yield cls(
@@ -355,7 +360,8 @@ class DocFiles(PythonDocstrings):
         if top_dir.endswith(".py"):
             return
 
-        for path, _folders, filenames in os.walk(top_dir):
+        for path, folders, filenames in os.walk(top_dir):
+            folders[:] = [d for d in folders if d not in FOLDERS_TO_IGNORE]
             for filename in filenames:
                 if filename.endswith(".txt") or filename.endswith(".rst"):
                     yield cls(
@@ -405,7 +411,8 @@ class DjangoSettings(PythonModule):
         if top_dir.endswith(".py"):
             return
 
-        for path, _folders, filenames in os.walk(top_dir):
+        for path, folders, filenames in os.walk(top_dir):
+            folders[:] = [d for d in folders if d not in FOLDERS_TO_IGNORE]
             for filename in filenames:
                 if fnmatch.fnmatch(filename, "*settings.py"):
                     yield cls(


### PR DESCRIPTION
Partially fixes #65 

I ignored both `node_modules` and `__pycache__`, more folder names can be easily added.

For the python scanner we are already removing all folders that do __not__ contain an `__init__.py` file, which might bite us eventually 🤔 as some recent python/setuptools versions allow implicit namespaces without an `__init__.py`, I can't remember the PEP number, I can look it up, but that's beyond this PR 😄 