### PR TITLE
ZCML `implements` directive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog of z3c.dependencychecker
 - Add `Plone` as an umbrella distribution, alongside `Zope`.
   [gforcada]
 
+- Scan the `<implements` directive on `ZCML` files.
+  [gforcada]
+
 2.11 (2023-03-03)
 -----------------
 

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -136,6 +136,7 @@ class ZCMLFile(BaseModule):
         "subscriber": ("handler", "for"),
         "securityPolicy": ("component",),
         "genericsetup:registerProfile": ("provides",),
+        "implements": ("interface",),
     }
 
     @classmethod

--- a/z3c/dependencychecker/tests/test_modules_zcml.py
+++ b/z3c/dependencychecker/tests/test_modules_zcml.py
@@ -16,30 +16,6 @@ ZCML_TEMPLATE = """
 </configure>
 """
 
-INCLUDE = '<include package="my.package.include" />'
-ADAPTER_FACTORY = '<adapter factory="my.package.factory" />'
-ADAPTER_FOR = '<adapter for="my.package.for" />'
-ADAPTER_FOR_MULTIPLE = (
-    '<adapter for="my.package.for another.package.foo yet.another.one" />'  # noqa
-)
-ADAPTER_PROVIDES = '<adapter provides="my.package.provides" />'
-UTILITY_COMPONENT = '<utility component="my.package.component" />'
-UTILITY_PROVIDES = '<utility provides="my.package.provides" />'
-BROWSER_PAGE_CLASS = '<browser:page class="my.package.class" />'
-BROWSER_PAGE_FOR = '<browser:page for="my.package.for" />'
-BROWSER_PAGE_LAYER = '<browser:page layer="my.package.layer" />'
-SUBSCRIBER_FOR = '<subscriber for="my.package.for" />'
-SUBSCRIBER_FOR_MULTIPLE = """<subscriber for="my.package.for
-                 another.package" />
-"""
-SUBSCRIBER_HANDLER = '<subscriber handler="my.package.handler" />'
-SECURITYPOLICY_COMPONENT = '<securityPolicy component="my.package.component" />'  # noqa
-GS_REGISTERPROFILE_PROVIDES = (
-    '<genericsetup:registerProfile provides="my.package.provides" />'  # noqa
-)
-IGNORE_LOCAL_IMPORT = '<adapter factory=".package.factory" />'
-ASTERISK = '<adapter for="*" />'
-
 RELATIVE_IMPORT = ".IRuleAssignable"
 ABSOLUTE_IMPORT_1 = "plone.interfaces.IContent"
 ABSOLUTE_IMPORT_2 = "zope.interfaces.IFolder"
@@ -96,175 +72,64 @@ def test_create_from_files_deep_nested(minimal_structure):
     assert len(modules_found) == 1
 
 
-def test_include(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, INCLUDE)
-    assert len(dotted_names) == 1
+@pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)
+def test_zcml_include(tmpdir, result, imports):
+    """Check that the ZCML <include directive is scanned."""
+    zcml_stanza = f'<include package="{imports}" />'
+    dotted_names = _get_zcml_imports_on_file(tmpdir, zcml_stanza)
+    _verify_dotted_names(dotted_names, imports, result)
 
 
-def test_include_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, INCLUDE)
-    assert dotted_names == ["my.package.include"]
+@pytest.mark.parametrize("attribute", ("for", "factory", "provides"))
+@pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)
+def test_zcml_adapter(tmpdir, result, imports, attribute):
+    """Check that the ZCML <adapter directive is scanned."""
+    zcml_stanza = f'<adapter {attribute}="{imports}" />'
+    dotted_names = _get_zcml_imports_on_file(tmpdir, zcml_stanza)
+    _verify_dotted_names(dotted_names, imports, result)
 
 
-def test_adapter_factory(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FACTORY)
-    assert len(dotted_names) == 1
+@pytest.mark.parametrize("attribute", ("provides", "component"))
+@pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)
+def test_zcml_utility(tmpdir, result, imports, attribute):
+    """Check that the ZCML <utility directive is scanned."""
+    zcml_stanza = f'<utility {attribute}="{imports}" />'
+    dotted_names = _get_zcml_imports_on_file(tmpdir, zcml_stanza)
+    _verify_dotted_names(dotted_names, imports, result)
 
 
-def test_adapter_factory_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FACTORY)
-    assert dotted_names == ["my.package.factory"]
+@pytest.mark.parametrize("attribute", ("class", "for", "layer"))
+@pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)
+def test_zcml_browser_page(tmpdir, result, imports, attribute):
+    """Check that the ZCML <browser:page directive is scanned."""
+    zcml_stanza = f'<browser:page {attribute}="{imports}" />'
+    dotted_names = _get_zcml_imports_on_file(tmpdir, zcml_stanza)
+    _verify_dotted_names(dotted_names, imports, result)
 
 
-def test_adapter_for(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FOR)
-    assert len(dotted_names) == 1
+@pytest.mark.parametrize("attribute", ("handler", "for"))
+@pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)
+def test_zcml_subscriber(tmpdir, result, imports, attribute):
+    """Check that the ZCML <subscriber directive is scanned."""
+    zcml_stanza = f'<subscriber {attribute}="{imports}" />'
+    dotted_names = _get_zcml_imports_on_file(tmpdir, zcml_stanza)
+    _verify_dotted_names(dotted_names, imports, result)
 
 
-def test_adapter_for_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FOR)
-    assert dotted_names == ["my.package.for"]
+@pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)
+def test_zcml_security_policy(tmpdir, result, imports):
+    """Check that the ZCML <securityPolicy directive is scanned."""
+    zcml_stanza = f'<securityPolicy component="{imports}" />'
+    dotted_names = _get_zcml_imports_on_file(tmpdir, zcml_stanza)
+    _verify_dotted_names(dotted_names, imports, result)
 
 
-def test_adapter_for_multiple(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FOR_MULTIPLE)
-    assert len(dotted_names) == 3
-
-
-def test_adapter_for_multiple_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_FOR_MULTIPLE)
-    assert "my.package.for" in dotted_names
-    assert "another.package.foo" in dotted_names
-    assert "yet.another.one" in dotted_names
-
-
-def test_adapter_provides(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_PROVIDES)
-    assert len(dotted_names) == 1
-
-
-def test_adapter_provides_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ADAPTER_PROVIDES)
-    assert dotted_names == ["my.package.provides"]
-
-
-def test_utility_component(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, UTILITY_COMPONENT)
-    assert len(dotted_names) == 1
-
-
-def test_utility_component_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, UTILITY_COMPONENT)
-    assert dotted_names == ["my.package.component"]
-
-
-def test_utility_provides(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, UTILITY_PROVIDES)
-    assert len(dotted_names) == 1
-
-
-def test_utility_provides_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, UTILITY_PROVIDES)
-    assert dotted_names == ["my.package.provides"]
-
-
-def test_browser_page_class(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, BROWSER_PAGE_CLASS)
-    assert len(dotted_names) == 1
-
-
-def test_browser_page_class_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, BROWSER_PAGE_CLASS)
-    assert dotted_names == ["my.package.class"]
-
-
-def test_browser_page_for(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, BROWSER_PAGE_FOR)
-    assert len(dotted_names) == 1
-
-
-def test_browser_page_for_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, BROWSER_PAGE_FOR)
-    assert dotted_names == ["my.package.for"]
-
-
-def test_browser_page_layer(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, BROWSER_PAGE_LAYER)
-    assert len(dotted_names) == 1
-
-
-def test_browser_page_layer_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, BROWSER_PAGE_LAYER)
-    assert dotted_names == ["my.package.layer"]
-
-
-def test_subscriber_for(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_FOR)
-    assert len(dotted_names) == 1
-
-
-def test_subscriber_for_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_FOR)
-    assert dotted_names == ["my.package.for"]
-
-
-def test_subscriber_for_multiple(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_FOR_MULTIPLE)
-    assert len(dotted_names) == 2
-
-
-def test_subscriber_for_multiple_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_FOR_MULTIPLE)
-    assert dotted_names == [
-        "my.package.for",
-        "another.package",
-    ]
-
-
-def test_subscriber_handler(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_HANDLER)
-    assert len(dotted_names) == 1
-
-
-def test_subscriber_handler_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SUBSCRIBER_HANDLER)
-    assert dotted_names == ["my.package.handler"]
-
-
-def test_securitypolicy_component(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SECURITYPOLICY_COMPONENT)
-    assert len(dotted_names) == 1
-
-
-def test_securitypolicy_component_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, SECURITYPOLICY_COMPONENT)
-    assert dotted_names == ["my.package.component"]
-
-
-def test_gs_registerprofile_provides(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(
-        tmpdir,
-        GS_REGISTERPROFILE_PROVIDES,
-    )
-    assert len(dotted_names) == 1
-
-
-def test_gs_registerprofile_provides_details(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(
-        tmpdir,
-        GS_REGISTERPROFILE_PROVIDES,
-    )
-    assert dotted_names == ["my.package.provides"]
-
-
-def test_ignore_local_import(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, IGNORE_LOCAL_IMPORT)
-    assert len(dotted_names) == 0
-
-
-def test_ignore_asterisk_import(tmpdir):
-    dotted_names = _get_zcml_imports_on_file(tmpdir, ASTERISK)
-    assert len(dotted_names) == 0
+@pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)
+def test_zcml_genericsetup(tmpdir, result, imports):
+    """Check that the ZCML <genericsetup:registerProfile directive is scanned."""
+    zcml_stanza = f'<genericsetup:registerProfile provides="{imports}" />'
+    dotted_names = _get_zcml_imports_on_file(tmpdir, zcml_stanza)
+    _verify_dotted_names(dotted_names, imports, result)
 
 
 @pytest.mark.parametrize("result,imports", TEST_IMPORTS_MATRIX)


### PR DESCRIPTION
Closes #110 

`pytest.mark.parametrize` is wonderful ✨ 🪄 🐰 

The first commit is where the actual `<implements` is added, the second is a big refactoring of the tests to use the same approach used for `<implements`.

We could go one step further and combine all tests into a single giant test, but maybe is too much? 😅 

Notice that if you add multiple `@pytest.mark.parametrize` it does the product of the elements, i.e.

```python
@pytest.mark.parametrize("one,two", (1,2), (3,4))
@pytest.mark.parametrize("three,four", (5,6), (7,8), (9,10))
```

Will run:
- `1,2`, `5,6`
- `1,2`, `7,8`
- `1,2`, `9,10`
- `3,4`, `5,6`
- `3,4`, `7,8`
- `3,4`, `9,10`