### PR TITLE
Handle modern distributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Changelog of z3c.dependencychecker
 - Scan the `<implements` directive on `ZCML` files.
   [gforcada]
 
+- Handle new distributions that no longer have a `setup.py`.
+  Consider `pyproject.toml` and `setup.cfg` alongside `setup.py`.
+  [gforcada]
+
 2.11 (2023-03-03)
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ long_description = f"""
 setup(
     name="z3c.dependencychecker",
     version=version,
-    description="Reports on missing or unneeded setup.py dependencies",
+    description="Reports on missing or unneeded python dependencies",
     long_description=long_description,
     long_description_content_type="text/x-rst; charset=UTF-8",
     # Get strings from https://pypi.org/classifiers/

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -40,7 +40,7 @@ class ImportsDatabase:
             )
 
             logger.warning(
-                'extra requirement "%s" is declared twice in setup.py',
+                'extra requirement "%s" is declared twice',
                 extra_name,
             )
         else:

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -39,7 +39,7 @@ class PackageMetadata:
                 break
         else:
             logger.error(
-                "No distribution configuration file was not found in %s. "
+                "No distribution configuration file was found in %s. "
                 "Without it dependencychecker can not work.",
                 self._path,
             )

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -39,7 +39,7 @@ class PackageMetadata:
                 break
         else:
             logger.error(
-                "setup.py was not found in %s. "
+                "No distribution configuration file was not found in %s. "
                 "Without it dependencychecker can not work.",
                 self._path,
             )
@@ -123,7 +123,7 @@ class PackageMetadata:
             logger.error(
                 "Package %s could not be found.\n"
                 "You might need to put it in development mode,\n"
-                "i.e. python setup.py develop",
+                "i.e. python setup.py develop or python -m build",
                 self.name,
             )
             sys.exit(1)
@@ -138,7 +138,7 @@ class PackageMetadata:
             )
 
     def get_extras_dependencies(self):
-        """Get this packages' extras dependencies defined in setup.py"""
+        """Get this packages' extras dependencies defined in its configuration"""
         this_package = self._get_ourselves_from_working_set()
 
         for extra_name in this_package.extras:
@@ -221,12 +221,12 @@ class Package:
         self.analyze_package()
 
     def set_declared_dependencies(self):
-        """Add this packages' dependencies defined in setup.py to the database"""
+        """Add this packages' dependencies defined in its configuration to the database"""
         self.imports.add_requirements(self.metadata.get_required_dependencies())
 
     def set_declared_extras_dependencies(self):
-        """Add this packages' extras dependencies defined in setup.py to the
-        database
+        """Add this packages' extras dependencies defined in its configuration
+        to the database
         """
         for extra, dotted_names in self.metadata.get_extras_dependencies():
             self.imports.add_extra_requirements(extra, dotted_names)

--- a/z3c/dependencychecker/package.py
+++ b/z3c/dependencychecker/package.py
@@ -39,7 +39,7 @@ class PackageMetadata:
                 break
         else:
             logger.error(
-                "No distribution configuration file was found in %s. "
+                "No pyproject.toml/setup.py/.cfg was found in %s. "
                 "Without it dependencychecker can not work.",
                 self._path,
             )

--- a/z3c/dependencychecker/report.py
+++ b/z3c/dependencychecker/report.py
@@ -56,8 +56,8 @@ class Report:
     def print_notice():
         print("")
         print("Note: requirements are taken from the egginfo dir, so you need")
-        print("to re-run buildout (or setup.py or whatever) for changes in")
-        print("setup.py to have effect.")
+        print("to re-generate it, via `python -m build`, setuptools, zc.buildout")
+        print("or any other means.")
         print("")
 
     def _print_metric(self, title, method):

--- a/z3c/dependencychecker/tests/test_imports_database.py
+++ b/z3c/dependencychecker/tests/test_imports_database.py
@@ -73,7 +73,7 @@ def test_warning_extra_declared_twice(caplog):
     database.add_extra_requirements("test", [DottedName("two")])
 
     last_log = caplog.records[-1]
-    message = 'extra requirement "test" is declared twice in setup.py'
+    message = 'extra requirement "test" is declared twice'
     assert message == last_log.message
 
 

--- a/z3c/dependencychecker/tests/test_integration.py
+++ b/z3c/dependencychecker/tests/test_integration.py
@@ -42,8 +42,8 @@ Unneeded test requirements
      zope.testing
 
 Note: requirements are taken from the egginfo dir, so you need
-to re-run buildout (or setup.py or whatever) for changes in
-setup.py to have effect.
+to re-generate it, via `python -m build`, setuptools, zc.buildout
+or any other means.
 
 """
 

--- a/z3c/dependencychecker/tests/test_package_metadata.py
+++ b/z3c/dependencychecker/tests/test_package_metadata.py
@@ -3,8 +3,9 @@ import shutil
 import tempfile
 
 import pkg_resources
+import pytest
 
-from z3c.dependencychecker.package import PackageMetadata
+from z3c.dependencychecker.package import METADATA_FILES, PackageMetadata
 
 
 def test_no_setup_py_file_found():
@@ -25,11 +26,18 @@ def test_distribution_root(minimal_structure):
     assert metadata.distribution_root == path
 
 
-def test_setup_py_path(minimal_structure):
+@pytest.mark.parametrize("filename", METADATA_FILES)
+def test_metadata_file_path(minimal_structure, filename):
     path, package_name = minimal_structure
-    metadata = PackageMetadata(path)
+    setup_py_path = os.path.join(path, "setup.py")
+    os.remove(setup_py_path)
 
-    assert metadata.setup_py_path == os.path.join(path, "setup.py")
+    file_path = os.path.join(path, filename)
+    with open(file_path, "w") as file_handler:
+        file_handler.write("hi")
+
+    metadata = PackageMetadata(path)
+    assert metadata.metadata_file_path == file_path
 
 
 def test_package_dir_on_distribution_root(minimal_structure):


### PR DESCRIPTION
Closes #107 

Actually, we _never_ parse `setup.py`, but rather get the information from the `egg-info` folder. So we might skip completely any reference to the configuration files and ask only to build the distribution in a way that an `egg-info` is created.