### PR TITLE
Pathlib everywhere

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.11", "3.10", 3.9, 3.8, pypy-3.9]
+        python-version: ["3.12", "3.11", "3.9", "3.8", "pypy-3.9"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog of z3c.dependencychecker
 2.14.4 (unreleased)
 -------------------
 
-- Use `pathlib.Path` everywhere to make it easier to reason about paths.
+- Use `pathlib.Path` everywhere to make it easier to reason about
+  paths.  Note that python 3.10 somehow manages to complain about
+  ``AttributeError: 'PosixPath' object has no attribute
+  'startswith'``, even though 3.8/.9/.11/.12 and pypy work fine. So if
+  you get that error, use a different python version...
   [gforcada]
 
 2.14.3 (2023-12-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog of z3c.dependencychecker
 2.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Use `pathlib.Path` everywhere to make it easier to reason about paths.
+  [gforcada]
 
 2.14 (2023-12-28)
 -----------------

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -356,7 +356,7 @@ class ImportsDatabase:
             libraries = list(
                 set(list(sys.stdlib_module_names) + list(sys.builtin_module_names))
             )
-        else:
+        else:  # pragma: no cover
             from stdlib_list import stdlib_list
 
             python_version = sys.version_info

--- a/z3c/dependencychecker/db.py
+++ b/z3c/dependencychecker/db.py
@@ -351,7 +351,7 @@ class ImportsDatabase:
 
     @staticmethod
     def _build_std_library():
-        if PY_10_OR_HIGHER:
+        if PY_10_OR_HIGHER:  # pragma: no cover
             # see https://github.com/jackmaney/python-stdlib-list/issues/55
             libraries = list(
                 set(list(sys.stdlib_module_names) + list(sys.builtin_module_names))

--- a/z3c/dependencychecker/main.py
+++ b/z3c/dependencychecker/main.py
@@ -2,6 +2,7 @@ import logging
 import optparse
 import os
 import sys
+from pathlib import Path
 
 import pkg_resources
 
@@ -72,14 +73,14 @@ def get_path(args):
     If no path is given on the command line arguments, the current working
     directory is used instead.
     """
-    path = os.getcwd()
+    path = Path(os.getcwd())
 
     if len(args) < 1:
         logger.debug("path used: %s", path)
         return path
 
-    path = os.path.abspath(args[0])
-    if os.path.isdir(path):
+    path = Path(args[0]).resolve()
+    if path.is_dir():
         logger.debug("path used: %s", path)
         return path
 

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -38,7 +38,7 @@ class BaseModule:
 
     @staticmethod
     def _get_relative_path(package_path, full_path):
-        return full_path[len(package_path) :]
+        return str(full_path)[len(str(package_path)) :]
 
     def _is_test_module(self):
         return bool(re.search(TEST_IN_PATH_REGEX, self._relative_path))
@@ -64,7 +64,7 @@ class PythonModule(BaseModule):
         Return this very same class, which would allow to call the scan()
         method to get an iterator over all this file's imports.
         """
-        if top_dir.endswith(".py"):
+        if top_dir.suffix == ".py":
             yield cls(top_dir, top_dir)
             return
 
@@ -141,7 +141,7 @@ class ZCMLFile(BaseModule):
         Return this very same class, which would allow to call the scan()
         method to get an iterator over all this file's imports.
         """
-        if top_dir.endswith(".py"):
+        if top_dir.suffix == ".py":
             return
 
         for path, folders, filenames in os.walk(top_dir):
@@ -206,7 +206,7 @@ class FTIFile(BaseModule):
         Return this very same class, which would allow to call the scan()
         method to get an iterator over all this file's imports.
         """
-        if top_dir.endswith(".py"):
+        if top_dir.suffix == ".py":
             return
 
         for path, folders, filenames in os.walk(top_dir):
@@ -249,7 +249,7 @@ class GSMetadata(BaseModule):
         Return this very same class, which would allow to call the scan()
         method to get an iterator over all this file's imports.
         """
-        if top_dir.endswith(".py"):
+        if top_dir.suffix == ".py":
             return
 
         for path, folders, filenames in os.walk(top_dir):
@@ -345,7 +345,7 @@ class DocFiles(PythonDocstrings):
         Return this very same class, which would allow to call the scan()
         method to get an iterator over all this file's imports.
         """
-        if top_dir.endswith(".py"):
+        if top_dir.suffix == ".py":
             return
 
         for path, folders, filenames in os.walk(top_dir):
@@ -396,7 +396,7 @@ class DjangoSettings(PythonModule):
         Return this very same class, which would allow to call the scan()
         method to get an iterator over all this file's imports.
         """
-        if top_dir.endswith(".py"):
+        if top_dir.suffix == ".py":
             return
 
         for path, folders, filenames in os.walk(top_dir):

--- a/z3c/dependencychecker/modules.py
+++ b/z3c/dependencychecker/modules.py
@@ -358,6 +358,12 @@ class DocFiles(PythonDocstrings):
                     )
 
     def scan(self):
+        try:
+            yield from self._scan()
+        except UnicodeDecodeError:
+            logger.error("Unicode Problems parsing %s", self.path)
+
+    def _scan(self):
         with open(self.path) as doc_file:
             for line in doc_file:
                 code = self._extract_code(line)

--- a/z3c/dependencychecker/tests/test_main.py
+++ b/z3c/dependencychecker/tests/test_main.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import tempfile
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -77,7 +78,7 @@ def test_get_path_no_path_given():
 
 def test_get_path_path_given():
     """If a path is given, that's the path being returned"""
-    folder = tempfile.mkdtemp()
+    folder = Path(tempfile.mkdtemp())
     arguments = [folder]
     path = get_path(arguments)
 
@@ -100,7 +101,7 @@ def test_get_path_given_path_not_a_folder():
 def test_exit_zero_not_set(minimal_structure):
     path, _ = minimal_structure
 
-    arguments = ["dependencychecker", path]
+    arguments = ["dependencychecker", str(path)]
     with pytest.raises(SystemExit):
         with mock.patch.object(sys, "argv", arguments):
             main()
@@ -109,7 +110,7 @@ def test_exit_zero_not_set(minimal_structure):
 def test_exit_zero_set(minimal_structure):
     path, _ = minimal_structure
 
-    arguments = ["dependencychecker", "--exit-zero", path]
+    arguments = ["dependencychecker", "--exit-zero", str(path)]
     with pytest.raises(SystemExit):
         with mock.patch.object(sys, "argv", arguments):
             main()

--- a/z3c/dependencychecker/tests/test_main.py
+++ b/z3c/dependencychecker/tests/test_main.py
@@ -81,8 +81,9 @@ def test_get_path_path_given():
     folder = Path(tempfile.mkdtemp())
     arguments = [folder]
     path = get_path(arguments)
-
-    assert path == folder
+    # .resolve() below makes it absolute: osx has /private/var/... !=
+    # /var/... otherwise...
+    assert path.resolve() == folder.resolve()
 
 
 def test_get_path_given_path_not_a_folder():

--- a/z3c/dependencychecker/tests/test_modules_base.py
+++ b/z3c/dependencychecker/tests/test_modules_base.py
@@ -1,5 +1,5 @@
-import os
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -8,66 +8,68 @@ from z3c.dependencychecker.tests.utils import write_source_file_at
 
 
 def test_module_path():
-    obj = BaseModule("/some/path", "/some/path/random/bla")
-    assert obj.path == "/some/path/random/bla"
+    full_path = Path("some") / "path" / "random" / "bla"
+    obj = BaseModule(Path("some") / "path", full_path)
+    assert obj.path == full_path
 
 
 def test_scan_raises():
-    obj = BaseModule("/some/path", "/some/path/random/bla")
+    full_path = Path("some") / "path" / "random" / "bla"
+    obj = BaseModule(Path("some") / "path", full_path)
     with pytest.raises(NotImplementedError):
         obj.scan()
 
 
 def test_create_from_files_raises():
     with pytest.raises(NotImplementedError):
-        BaseModule.create_from_files("/some/path")
+        BaseModule.create_from_files(Path("some") / "path")
 
 
 def test_has_test_with_prefix_in_path():
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "blatest"))
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "blatest")
     python_module = BaseModule(folder, temporal_file)
     assert python_module.testing
 
 
 def test_has_test_in_path():
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "test"))
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "test")
     python_module = BaseModule(folder, temporal_file)
     assert python_module.testing
 
 
 def test_has_tests_in_path():
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "tests"))
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "tests")
     python_module = BaseModule(folder, temporal_file)
     assert python_module.testing
 
 
 def test_has_test_in_filename():
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "bla"), filename="test.py")
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "bla", filename="test.py")
     python_module = BaseModule(folder, temporal_file)
     assert python_module.testing
 
 
 def test_has_tests_in_filename():
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "bla"), filename="tests.py")
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "bla", filename="tests.py")
     python_module = BaseModule(folder, temporal_file)
     assert python_module.testing
 
 
 def test_has_tests_with_suffix_in_filename():
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "bla"), filename="testsohlala.py")
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "bla", filename="testsohlala.py")
     python_module = BaseModule(folder, temporal_file)
     assert python_module.testing
 
 
 def test_is_not_a_test_module():
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "bla"), filename="bla.py")
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "bla", filename="bla.py")
     python_module = BaseModule(folder, temporal_file)
     assert python_module.testing is False
 
@@ -83,7 +85,7 @@ def test_parent_folder_is_test_but_module_not():
     Despite having 'test' in the path, as it is not part of the package,
     it should be ignored.
     """
-    folder = tempfile.mkdtemp()
-    temporal_file = write_source_file_at((folder, "test", "bla"), filename="bla.py")
-    python_module = BaseModule(os.path.join(folder, "test"), temporal_file)
+    folder = Path(tempfile.mkdtemp())
+    temporal_file = write_source_file_at(folder / "test" / "bla", filename="bla.py")
+    python_module = BaseModule(folder / "test", temporal_file)
     assert python_module.testing is False

--- a/z3c/dependencychecker/tests/test_modules_django_settings.py
+++ b/z3c/dependencychecker/tests/test_modules_django_settings.py
@@ -1,5 +1,5 @@
-import os
 import tempfile
+from pathlib import Path
 
 from z3c.dependencychecker.modules import DjangoSettings
 from z3c.dependencychecker.tests.utils import write_source_file_at
@@ -15,12 +15,13 @@ TEST_RUNNER_ASSIGNMENT_TO_STRING = 'TEST_RUNNER = "random8"'
 
 
 def _get_imports_of_python_module(folder, source):
+    folder = Path(folder)
     temporal_file = write_source_file_at(
-        (folder.strpath,),
+        folder,
         source_code=source,
     )
 
-    django_settings = DjangoSettings(folder.strpath, temporal_file)
+    django_settings = DjangoSettings(folder, temporal_file)
     dotted_names = [x.name for x in django_settings.scan()]
     return dotted_names
 
@@ -33,23 +34,23 @@ def test_create_from_files_nothing(minimal_structure):
 
 def test_create_from_files_single_file_random_name():
     _, tmp_file = tempfile.mkstemp(".py")
-    modules_found = list(DjangoSettings.create_from_files(tmp_file))
+    modules_found = list(DjangoSettings.create_from_files(Path(tmp_file)))
     assert len(modules_found) == 0
 
 
 def test_create_from_files_single_file_settings_name(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
-    write_source_file_at([src_path], filename="some_settings.py")
+    src_path = path / "src"
+    write_source_file_at(src_path, filename="some_settings.py")
     modules_found = list(DjangoSettings.create_from_files(src_path))
     assert len(modules_found) == 1
 
 
 def test_create_from_files_deep_nested(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
+    src_path = path / "src"
     write_source_file_at(
-        [src_path, "a", "b", "c"],
+        src_path / "a" / "b" / "c",
         filename="anothersettings.py",
     )
     modules_found = list(DjangoSettings.create_from_files(src_path))

--- a/z3c/dependencychecker/tests/test_modules_docfiles.py
+++ b/z3c/dependencychecker/tests/test_modules_docfiles.py
@@ -93,7 +93,7 @@ def test_unicode_decode_error():
             raise UnicodeDecodeError(
                 "funnycodec", o, 1, 2, "This is just a fake reason!"
             )
-        yield "dummy yieldto make it an iterable"
+        yield "dummy yieldto make it an iterable"  # pragma: no cover
 
     docfiles._scan = mock_scan
     # The unicode error logs an error but continues otherwise.

--- a/z3c/dependencychecker/tests/test_modules_docfiles.py
+++ b/z3c/dependencychecker/tests/test_modules_docfiles.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from z3c.dependencychecker.modules import DocFiles
 from z3c.dependencychecker.tests.utils import write_source_file_at
@@ -52,28 +52,28 @@ class MyClass(object):',
 
 
 def _get_dependencies_on_file(folder, source):
+    folder = Path(folder)
     temporal_file = write_source_file_at(
-        (folder.strpath,),
+        folder,
         source_code=source,
     )
 
-    doc_file = DocFiles(folder.strpath, temporal_file)
+    doc_file = DocFiles(folder, temporal_file)
     dotted_names = [x.name for x in doc_file.scan()]
     return dotted_names
 
 
 def test_create_from_files_nothing(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
-    modules_found = list(DocFiles.create_from_files(src_path))
+    modules_found = list(DocFiles.create_from_files(path / "src"))
     assert len(modules_found) == 0
 
 
 def test_create_from_files_deep_nested_txt(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
+    src_path = path / "src"
     write_source_file_at(
-        [src_path, "a", "b", "c"],
+        src_path / "a" / "b" / "c",
         filename="bla.txt",
     )
 
@@ -83,9 +83,9 @@ def test_create_from_files_deep_nested_txt(minimal_structure):
 
 def test_create_from_files_deep_nested_rst(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
+    src_path = path / "src"
     write_source_file_at(
-        [src_path, "a", "b", "c"],
+        src_path / "a" / "b" / "c",
         filename="bla.rst",
     )
 
@@ -114,11 +114,12 @@ def test_code_found_details(tmpdir):
 
 
 def test_always_testing(tmpdir):
+    tmpdir = Path(tmpdir)
     temporal_file = write_source_file_at(
-        (tmpdir.strpath,), source_code=">>> import foo", filename="file.rst"
+        tmpdir, source_code=">>> import foo", filename="file.rst"
     )
 
-    doc_file = DocFiles(tmpdir.strpath, temporal_file)
+    doc_file = DocFiles(tmpdir, temporal_file)
     dotted_names = list(doc_file.scan())
     assert len(dotted_names) == 1
     assert dotted_names[0].is_test

--- a/z3c/dependencychecker/tests/test_modules_docfiles.py
+++ b/z3c/dependencychecker/tests/test_modules_docfiles.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest import mock
 
 from z3c.dependencychecker.modules import DocFiles
 from z3c.dependencychecker.tests.utils import write_source_file_at
@@ -84,14 +83,19 @@ def test_create_from_files_deep_nested_txt(minimal_structure):
 
 def test_unicode_decode_error():
     docfiles = DocFiles("somewhere", "some_file")
-    docfiles._scan = mock.MagicMock
-    # Thanks to
-    # https://gehrcke.de/2015/12/how-to-raise-unicodedecodeerror-in-python-3/
-    # for the error syntax :-)
-    o = b"\x00\x00"
-    docfiles._scan.side_effect = UnicodeDecodeError(
-        "funnycodec", o, 1, 2, "This is just a fake reason!"
-    )
+
+    def mock_scan():
+        # Thanks to
+        # https://gehrcke.de/2015/12/how-to-raise-unicodedecodeerror-in-python-3/
+        # for the error syntax :-)
+        o = b"\x00\x00"
+        if True:
+            raise UnicodeDecodeError(
+                "funnycodec", o, 1, 2, "This is just a fake reason!"
+            )
+        yield "dummy yieldto make it an iterable"
+
+    docfiles._scan = mock_scan
     # The unicode error logs an error but continues otherwise.
     assert list(docfiles.scan()) == []
 

--- a/z3c/dependencychecker/tests/test_modules_docfiles.py
+++ b/z3c/dependencychecker/tests/test_modules_docfiles.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 from z3c.dependencychecker.modules import DocFiles
 from z3c.dependencychecker.tests.utils import write_source_file_at
@@ -79,6 +80,20 @@ def test_create_from_files_deep_nested_txt(minimal_structure):
 
     modules_found = list(DocFiles.create_from_files(src_path))
     assert len(modules_found) == 1
+
+
+def test_unicode_decode_error():
+    docfiles = DocFiles("somewhere", "some_file")
+    docfiles._scan = mock.MagicMock
+    # Thanks to
+    # https://gehrcke.de/2015/12/how-to-raise-unicodedecodeerror-in-python-3/
+    # for the error syntax :-)
+    o = b"\x00\x00"
+    docfiles._scan.side_effect = UnicodeDecodeError(
+        "funnycodec", o, 1, 2, "This is just a fake reason!"
+    )
+    # The unicode error logs an error but continues otherwise.
+    assert list(docfiles.scan()) == []
 
 
 def test_create_from_files_deep_nested_rst(minimal_structure):

--- a/z3c/dependencychecker/tests/test_modules_docstrings.py
+++ b/z3c/dependencychecker/tests/test_modules_docstrings.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from z3c.dependencychecker.modules import PythonDocstrings
 from z3c.dependencychecker.tests.utils import write_source_file_at
 
@@ -66,12 +68,13 @@ class MyClass(object):
 
 
 def _get_dependencies_on_file(folder, source):
+    folder = Path(folder)
     temporal_file = write_source_file_at(
-        (folder.strpath,),
+        folder,
         source_code=source,
     )
 
-    docstring = PythonDocstrings(folder.strpath, temporal_file)
+    docstring = PythonDocstrings(folder, temporal_file)
     dotted_names = [x.name for x in docstring.scan()]
     return dotted_names
 

--- a/z3c/dependencychecker/tests/test_modules_fti.py
+++ b/z3c/dependencychecker/tests/test_modules_fti.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from z3c.dependencychecker.modules import FTIFile
 from z3c.dependencychecker.tests.utils import write_source_file_at
@@ -35,13 +35,14 @@ SCHEMA_EMPTY = '<property name="schema"></property>'
 
 def _get_fti_imports_on_file(folder, source):
     full_content = XML_TEMPLATE.format(source)
+    folder = Path(folder)
     temporal_file = write_source_file_at(
-        (folder.strpath,),
+        folder,
         source_code=full_content,
         filename="configure.zcml",
     )
 
-    fti_file = FTIFile(folder.strpath, temporal_file)
+    fti_file = FTIFile(folder, temporal_file)
     dotted_names = [x.name for x in fti_file.scan()]
     return dotted_names
 
@@ -54,9 +55,9 @@ def test_create_from_files_nothing(minimal_structure):
 
 def test_create_from_files_deep_nested(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
+    src_path = path / "src"
     write_source_file_at(
-        [src_path, "a", "b", "c", "types"],
+        src_path / "a" / "b" / "c" / "types",
         filename="test.xml",
     )
 

--- a/z3c/dependencychecker/tests/test_modules_gs_metadata.py
+++ b/z3c/dependencychecker/tests/test_modules_gs_metadata.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from z3c.dependencychecker.modules import GSMetadata
 from z3c.dependencychecker.tests.utils import write_source_file_at
@@ -29,13 +29,14 @@ MORE_DEPENDENCIES = """
 
 def _get_dependencies_on_file(folder, source):
     full_content = XML_TEMPLATE.format(source)
+    folder = Path(folder)
     temporal_file = write_source_file_at(
-        (folder.strpath,),
+        folder,
         source_code=full_content,
         filename="configure.zcml",
     )
 
-    gs_metadata = GSMetadata(folder.strpath, temporal_file)
+    gs_metadata = GSMetadata(folder, temporal_file)
     dotted_names = [x.name for x in gs_metadata.scan()]
     return dotted_names
 
@@ -48,9 +49,9 @@ def test_create_from_files_nothing(minimal_structure):
 
 def test_create_from_files_deep_nested(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
+    src_path = path / "src"
     write_source_file_at(
-        [src_path, "a", "b", "c"],
+        src_path / "a" / "b" / "c",
         filename="metadata.xml",
     )
 

--- a/z3c/dependencychecker/tests/test_modules_zcml.py
+++ b/z3c/dependencychecker/tests/test_modules_zcml.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -38,13 +38,14 @@ TEST_IMPORTS_MATRIX = (
 
 def _get_zcml_imports_on_file(folder, source):
     full_content = ZCML_TEMPLATE.format(source)
+    folder = Path(folder.strpath)
     temporal_file = write_source_file_at(
-        (folder.strpath,),
+        folder,
         source_code=full_content,
         filename="configure.zcml",
     )
 
-    zcml_file = ZCMLFile(folder.strpath, temporal_file)
+    zcml_file = ZCMLFile(folder, temporal_file)
     dotted_names = [x.name for x in zcml_file.scan()]
     return dotted_names
 
@@ -65,8 +66,8 @@ def test_create_from_files_nothing(minimal_structure):
 
 def test_create_from_files_deep_nested(minimal_structure):
     path, package_name = minimal_structure
-    src_path = os.path.join(path, "src")
-    write_source_file_at([src_path, "a", "b"], filename="configure.zcml")
+    src_path = path / "src"
+    write_source_file_at(src_path / "a" / "b", filename="configure.zcml")
 
     modules_found = list(ZCMLFile.create_from_files(src_path))
     assert len(modules_found) == 1

--- a/z3c/dependencychecker/tests/test_package.py
+++ b/z3c/dependencychecker/tests/test_package.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from z3c.dependencychecker.package import Package, PackageMetadata
 from z3c.dependencychecker.tests.utils import (
@@ -31,13 +32,8 @@ def test_declared_dependencies(minimal_structure):
 
 def test_declared_dependencies_empty(minimal_structure):
     path, package_name = minimal_structure
-    requires_file_path = os.path.join(
-        path,
-        f"{package_name}.egg-info",
-        "requires.txt",
-    )
-    with open(requires_file_path, "w") as requires:
-        requires.write("")
+    requires_file_path = path / f"{package_name}.egg-info" / "requires.txt"
+    requires_file_path.write_text("")
 
     package = Package(path)
     package.set_declared_dependencies()
@@ -47,13 +43,10 @@ def test_declared_dependencies_empty(minimal_structure):
 
 def test_declared_extras_dependencies_one_extra(minimal_structure):
     path, package_name = minimal_structure
-    requires_file_path = os.path.join(
-        path,
-        f"{package_name}.egg-info",
-        "requires.txt",
+    requires_file_path = path / f"{package_name}.egg-info" / "requires.txt"
+    requires_file_path.write_text(
+        "\n".join(["[extra]", "my.package", "another.package"])
     )
-    with open(requires_file_path, "w") as requires:
-        requires.write("\n".join(["[extra]", "my.package", "another.package"]))
 
     package = Package(path)
     package.set_declared_dependencies()
@@ -70,15 +63,10 @@ def test_declared_extras_dependencies_one_extra(minimal_structure):
 def test_declared_extras_dependencies_only_on_extras(minimal_structure):
     """Check that main dependencies are not bundled on the extras"""
     path, package_name = minimal_structure
-    requires_file_path = os.path.join(
-        path,
-        f"{package_name}.egg-info",
-        "requires.txt",
+    requires_file_path = path / f"{package_name}.egg-info" / "requires.txt"
+    requires_file_path.write_text(
+        "\n".join(["setuptools", "", "[extra]", "my_package", "my_other_package"])
     )
-    with open(requires_file_path, "w") as requires:
-        requires.write(
-            "\n".join(["setuptools", "", "[extra]", "my_package", "my_other_package"])
-        )
 
     package = Package(path)
     package.set_declared_dependencies()
@@ -90,26 +78,21 @@ def test_declared_extras_dependencies_only_on_extras(minimal_structure):
 
 def test_multiple_extras(minimal_structure):
     path, package_name = minimal_structure
-    requires_file_path = os.path.join(
-        path,
-        f"{package_name}.egg-info",
-        "requires.txt",
-    )
-    with open(requires_file_path, "w") as requires:
-        requires.write(
-            "\n".join(
-                [
-                    "setuptools",
-                    "",
-                    "[extra]",
-                    "my_package",
-                    "my_other_package",
-                    "[second]",
-                    "just",
-                    "laughs",
-                ]
-            )
+    requires_file_path = path / f"{package_name}.egg-info" / "requires.txt"
+    requires_file_path.write_text(
+        "\n".join(
+            [
+                "setuptools",
+                "",
+                "[extra]",
+                "my_package",
+                "my_other_package",
+                "[second]",
+                "just",
+                "laughs",
+            ]
         )
+    )
 
     package = Package(path)
     package.set_declared_extras_dependencies()
@@ -129,7 +112,7 @@ def test_no_python_modules_found(minimal_structure):
 
 def test_python_modules_on_top_level_sources(minimal_structure):
     path, package_name = minimal_structure
-    write_source_file_at((path, package_name), "__init__.py")
+    write_source_file_at(path / package_name, "__init__.py")
     package = Package(path)
     package.analyze_package()
 
@@ -140,9 +123,9 @@ def test_python_modules_on_top_level_sources(minimal_structure):
 
 def test_python_modules_found_inner_folders(minimal_structure):
     path, package_name = minimal_structure
-    write_source_file_at((path, package_name), "__init__.py")
-    write_source_file_at((path, package_name, "test"), "__init__.py")
-    write_source_file_at((path, package_name, "test"), "test.py")
+    write_source_file_at(path / package_name, "__init__.py")
+    write_source_file_at(path / package_name / "test", "__init__.py")
+    write_source_file_at(path / package_name / "test", "test.py")
 
     package = Package(path)
     package.analyze_package()
@@ -156,18 +139,17 @@ def test_python_modules_found_inner_folders(minimal_structure):
 def test_top_level_is_a_file(minimal_structure):
     path, package_name = minimal_structure
 
-    egg_info_folder = os.path.join(path, f"{package_name}.egg-info")
-    top_level_file_path = os.path.join(egg_info_folder, "top_level.txt")
-    with open(top_level_file_path) as top_level_file:
-        top_level_folder = top_level_file.read().strip()
+    egg_info_folder = path / f"{package_name}.egg-info"
+    top_level_file_path = egg_info_folder / "top_level.txt"
+    top_level_folder = top_level_file_path.read_text().strip()
 
-    top_level_sources = os.path.join(path, top_level_folder)
+    top_level_sources = path / top_level_folder
     os.removedirs(top_level_sources)
-    with open(f"{top_level_sources}.py", "w") as top_level_file:
-        top_level_file.write("import one")
+    top_level_file = Path(f"{top_level_sources}.py")
+    top_level_file.write_text("import one")
 
     package = Package(path)
     package.analyze_package()
     paths = get_sorted_imports_paths(package.imports)
     assert len(paths) == 1
-    assert paths[0].endswith(f"{top_level_folder}.py")
+    assert paths[0].parts[-1] == f"{top_level_folder}.py"

--- a/z3c/dependencychecker/tests/test_report.py
+++ b/z3c/dependencychecker/tests/test_report.py
@@ -46,7 +46,7 @@ def test_missing_requirements_nothing(capsys):
 
 def test_missing_requirements(capsys, minimal_structure):
     path, package_name = minimal_structure
-    write_source_file_at((path, package_name), "__init__.py", "import another.package")
+    write_source_file_at(path / package_name, "__init__.py", "import another.package")
 
     package = Package(path)
     package.inspect()
@@ -61,17 +61,17 @@ def test_missing_requirements(capsys, minimal_structure):
 def test_missing_requirements_with_user_mapping(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "import Products.Five.browser.views.BrowserView",
     )
     write_source_file_at(
-        (path, f"{package_name}.egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "Zope2",
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(
             [
@@ -95,12 +95,12 @@ def test_missing_requirements_with_user_mapping(capsys, minimal_structure):
 def test_missing_requirements_with_ignored_packages(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "import Products.Five.browser.views.BrowserView",
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(
             [
@@ -125,12 +125,12 @@ def test_missing_requirements_with_ignored_packages(capsys, minimal_structure):
 def test_missing_test_requirements(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "import another.package",
     )
@@ -148,22 +148,22 @@ def test_missing_test_requirements(capsys, minimal_structure):
 def test_missing_test_requirements_with_user_mapping(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "import Products.Five.browser.views.BrowserView",
     )
     write_source_file_at(
-        (path, f"{package_name}.egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "Zope2",
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", 'Zope2 = ["Products.Five" ]']),
     )
@@ -185,22 +185,22 @@ def test_missing_test_requirements_with_user_mapping_on_test_extra(
 ):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "import Products.Five.browser.views.BrowserView",
     )
     write_source_file_at(
-        (path, f"{package_name}.egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["[test]", "Zope2"]),
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", 'Zope2 = ["Products.Five" ]']),
     )
@@ -220,17 +220,17 @@ def test_missing_test_requirements_with_user_mapping_on_test_extra(
 def test_missing_test_requirements_with_ignored_packages(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "import Products.Five.browser.views.BrowserView",
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(
             [
@@ -254,7 +254,7 @@ def test_missing_test_requirements_with_ignored_packages(capsys, minimal_structu
 def test_unneeded_requirements(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "import this.package",
     )
@@ -273,12 +273,12 @@ def test_unneeded_requirements(capsys, minimal_structure):
 def test_unneeded_requirements_with_ignored_packages(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "import this.package",
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(
             [
@@ -302,17 +302,17 @@ def test_unneeded_requirements_with_ignored_packages(capsys, minimal_structure):
 def test_unneeded_requirements_with_user_mapping(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "from BTrees import Tree",
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", '"ZODB3" = ["BTrees" ]']),
     )
     write_source_file_at(
-        (path, f"{package_name}.egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["ZODB3", "setuptools", "one"]),
     )
@@ -331,17 +331,17 @@ def test_unneeded_requirements_with_user_mapping(capsys, minimal_structure):
 def test_unneeded_requirements_with_user_mapping2(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "from Plone import Tree",
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", '"ZODB3" = ["BTrees" ]']),
     )
     write_source_file_at(
-        (path, f"{package_name}.egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["ZODB3", "setuptools", "one"]),
     )
@@ -360,7 +360,7 @@ def test_unneeded_requirements_with_user_mapping2(capsys, minimal_structure):
 def test_unneeded_test_requirements(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name + ".egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["[test]", "pytest", "mock"]),
     )
@@ -379,12 +379,12 @@ def test_unneeded_test_requirements(capsys, minimal_structure):
 def test_unneeded_test_requirements_with_ignore_packages(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name + ".egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["[test]", "pytest", "mock"]),
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", 'ignore-packages = ["mock" ]']),
     )
@@ -403,22 +403,22 @@ def test_unneeded_test_requirements_with_ignore_packages(capsys, minimal_structu
 def test_unneeded_test_requirements_with_user_mappings(capsys, minimal_structure):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name + ".egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["[test]", "pytest", "ZODB3"]),
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", '"ZODB3" = ["BTrees" ]']),
     )
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "from BTrees import Tree",
     )
@@ -456,17 +456,17 @@ def test_requirements_that_should_be_test_requirements(
 ):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "import one",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "import two",
     )
     write_source_file_at(
-        (path, package_name + ".egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["one", "two", "[test]", "pytest", "mock"]),
     )
@@ -490,22 +490,22 @@ def test_requirements_that_should_be_test_requirements_with_ignored_packages(
 ):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "import one",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "\n".join(["import two", "import three"]),
     )
     write_source_file_at(
-        (path, package_name + ".egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["one", "two", "three", "[test]", "pytest", "mock"]),
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", 'ignore-packages = ["two" ]']),
     )
@@ -530,22 +530,22 @@ def test_requirements_that_should_be_test_requirements_with_user_mappings(
 ):
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "import one",
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "\n".join(["import two", "import BTrees"]),
     )
     write_source_file_at(
-        (path, package_name + ".egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["one", "two", "ZODB3", "[test]", "pytest", "mock"]),
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", '"ZODB3" = ["BTrees" ]']),
     )
@@ -574,22 +574,22 @@ def test_requirements_that_should_be_test_requirements_with_user_mapping2(
     """
     path, package_name = minimal_structure
     write_source_file_at(
-        (path, package_name),
+        path / package_name,
         "__init__.py",
         "\n".join(["import one", "import two", "import part.of.meta"]),
     )
     write_source_file_at(
-        (path, package_name, "tests"),
+        path / package_name / "tests",
         "__init__.py",
         "\n".join(["import three", "import four", "import part.of.meta"]),
     )
     write_source_file_at(
-        (path, package_name + ".egg-info"),
+        path / f"{package_name}.egg-info",
         "requires.txt",
         "\n".join(["one", "two", "three", "meta-package", "[test]", "four"]),
     )
     write_source_file_at(
-        (path,),
+        path,
         "pyproject.toml",
         "\n".join(["[tool.dependencychecker]", 'meta-package = ["part.of.meta" ]']),
     )
@@ -691,11 +691,11 @@ def test_missing_requirements_report_zope_interface(
 
     for filename, content in files_data:
         if filename == "requires.txt":
-            folder = (path, package_name + ".egg-info")
+            folder = path / f"{package_name}.egg-info"
         elif filename == "pyproject.toml":
-            folder = (path,)
+            folder = path
         else:
-            folder = (path, package_name)
+            folder = path / package_name
 
         write_source_file_at(folder, filename, content)
 
@@ -759,11 +759,11 @@ def test_missing_requirements_report_zpublisher(
 
     for filename, content in files_data:
         if filename == "requires.txt":
-            folder = (path, package_name + ".egg-info")
+            folder = path / f"{package_name}.egg-info"
         elif filename == "pyproject.toml":
-            folder = (path,)
+            folder = path
         else:
-            folder = (path, package_name)
+            folder = path / package_name
 
         write_source_file_at(folder, filename, content)
 

--- a/z3c/dependencychecker/tests/test_user_mappings.py
+++ b/z3c/dependencychecker/tests/test_user_mappings.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from z3c.dependencychecker.dotted_name import DottedName
@@ -36,18 +34,11 @@ ignore-packages = ['django-toolbar', 'plone.reload']
 
 
 def _write_user_config(path, content):
-    file_path = os.sep.join(
-        [
-            path,
-            "pyproject.toml",
-        ]
-    )
-    with open(file_path, "w") as config_file:
-        config_file.write(content)
+    (path / "pyproject.toml").write_text(content)
 
 
 def _update_requires_txt(path, package_name, packages):
-    file_path = os.sep.join([path, f"{package_name}.egg-info", "requires.txt"])
+    file_path = path / f"{package_name}.egg-info" / "requires.txt"
     with open(file_path, "w") as config_file:
         for package in packages:
             config_file.write(f"{package}\n")

--- a/z3c/dependencychecker/tests/utils.py
+++ b/z3c/dependencychecker/tests/utils.py
@@ -1,22 +1,11 @@
-import os
-
-
 def write_source_file_at(
-    path_parts,
+    folder_path,
     filename="test.py",
     source_code="import unknown.dependency",
 ):
-    folder_path = os.path.join(*path_parts)
-
-    try:
-        os.makedirs(folder_path)
-    except OSError:
-        pass
-
-    file_path = os.path.join(folder_path, filename)
-    with open(file_path, "w") as new_file:
-        new_file.write(source_code)
-
+    folder_path.mkdir(parents=True, exist_ok=True)
+    file_path = folder_path / filename
+    file_path.write_text(source_code)
     return file_path
 
 


### PR DESCRIPTION
While looking at the code I noticed that we were using plenty of `os.sep` and `os.path.join` that since Python 3.4 is so much more nicer to use `pathlib.Path` instead.

The diff turned out quite big, but it's only about replacing old with new usages, no functionality changes.

As an extra bonus there are a couple of minor improvements added 😄 