### PR TITLE
Ignore all dot leading folders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog of z3c.dependencychecker
 2.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Ignore any dot leading folder (like `.tox` or `.git`) while scanning for files.
+  [gforcada]
 
 2.14 (2023-12-28)
 -----------------


### PR DESCRIPTION
@reinout indeed, ignoring all dot leading folders is important!!

I forgot to do some real testing, and once I did that, after the release, the first one already showed the problem: `.tox` stalls the processing 😕 

I refactored, a bit, the scanners to share the filtering logic on a single function 🧹 